### PR TITLE
feat(ui): add shared UI package

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "next": "^15.4.2-canary.16",

--- a/package.json
+++ b/package.json
@@ -5,15 +5,16 @@
   "author": "Kristian Matthews-Kennington <kristian@matthews-kennington.com>",
   "private": true,
   "workspaces": [
-    "apps/web"
+    "apps/web",
+    "packages/*"
   ],
   "scripts": {
     "web:dev": "yarn workspace web dev",
-    "build": "yarn workspace web build",
-    "lint": "yarn workspace web lint",
-    "lint:fix": "yarn workspace web lint --fix",
-    "typecheck": "yarn workspace web tsc --noEmit",
-    "test": "echo \"No tests yet\"",
+    "build": "yarn workspaces run build",
+    "lint": "yarn workspaces run lint",
+    "lint:fix": "yarn workspaces run lint --fix",
+    "typecheck": "yarn workspaces run tsc --noEmit",
+    "test": "yarn workspaces run test",
     "e2e": "echo \"No e2e tests yet\"",
     "web:ci": "yarn lint && yarn typecheck && yarn test && yarn e2e"
   }

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,3 @@
+# UI Package
+
+Shared React components styled with Tailwind CSS.

--- a/packages/ui/eslint.config.mjs
+++ b/packages/ui/eslint.config.mjs
@@ -1,0 +1,21 @@
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { FlatCompat } from '@eslint/eslintrc';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends('next/core-web-vitals', 'next/typescript'),
+  {
+    rules: {
+      'next/no-html-link-for-pages': 'off',
+    },
+  },
+];
+
+export default eslintConfig;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "ui",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint 'src/**/*.{ts,tsx}'",
+    "test": "vitest run"
+  },
+  "peerDependencies": {
+    "react": "^19",
+    "react-dom": "^19"
+  },
+  "devDependencies": {
+    "@eslint/eslintrc": "^3",
+    "@testing-library/jest-dom": "^6.6.4",
+    "@testing-library/react": "^16.3.0",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "eslint": "^9",
+    "jsdom": "^26.1.0",
+    "typescript": "^5",
+    "vitest": "^3.2.4",
+    "tailwindcss": "^4",
+    "@tailwindcss/postcss": "^4"
+  }
+}

--- a/packages/ui/src/__tests__/Button.test.tsx
+++ b/packages/ui/src/__tests__/Button.test.tsx
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { Button } from '../components/Button';
+
+describe('Button', () => {
+  it('renders label text', () => {
+    const { getByRole } = render(<Button label="Click me" />);
+    const button = getByRole('button', { name: /click me/i });
+    expect(button).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /**
+   * Button label
+   */
+  label: string;
+}
+
+/**
+ * Primary button component.
+ */
+export function Button({ label, className, ...props }: ButtonProps) {
+  return (
+    <button
+      type="button"
+      className={`rounded bg-foreground px-4 py-2 text-background hover:opacity-90 ${className ?? ''}`}
+      {...props}
+    >
+      {label}
+    </button>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,1 @@
+export * from './components/Button';

--- a/packages/ui/tailwind.config.ts
+++ b/packages/ui/tailwind.config.ts
@@ -1,0 +1,13 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: [
+    './src/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": false,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- create shared `ui` workspace with a button component
- enable testing and linting across all packages
- hook `vitest` into web and ui packages

Closes #1

------
https://chatgpt.com/codex/tasks/task_e_6886428558e08326a4fd526b803e97a8

## Summary by Sourcery

Add a new shared UI package with a primary Button component and unify workspace configuration and scripts to enable linting, type checking, building, and testing across the monorepo.

New Features:
- Introduce shared 'ui' workspace with a reusable React Button component

Enhancements:
- Restructure project into Yarn workspaces including the new packages directory
- Centralize build, lint, typecheck, and test scripts to run across all workspaces
- Configure ESLint, TypeScript, and Tailwind CSS in the UI package

Documentation:
- Add a basic README for the shared UI package

Tests:
- Hook Vitest into both web and ui packages and add unit tests for the Button component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a shared UI package with a reusable Button component styled using Tailwind CSS.
  * Added a README and configuration files for the new UI package, including TypeScript, ESLint, and Tailwind CSS support.

* **Tests**
  * Added an initial test for the Button component to ensure correct rendering.

* **Chores**
  * Updated workspace configuration to include all packages and adjusted scripts to run across all workspaces.
  * Added and updated package scripts for building, linting, type checking, and testing in both root and web app configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->