### PR TITLE
feat: add turbo configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules
 .yarn
 *.log
 .DS_Store
+.turbo
 

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["turbo.json", "package.json", "yarn.lock"],
+  "pipeline": {
+    "lint": {
+      "outputs": []
+    },
+    "typecheck": {
+      "dependsOn": ["^typecheck"],
+      "outputs": []
+    },
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".next/**"]
+    },
+    "test": {
+      "dependsOn": ["build"],
+      "outputs": ["coverage/**"]
+    },
+    "dev": {
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add turborepo pipeline config
- ignore `.turbo` cache folder

Closes #9

------
https://chatgpt.com/codex/tasks/task_e_68878ec485788326804c7bffe92dc7e5

## Summary by Sourcery

Add TurboRepo pipeline configuration and update .gitignore to ignore the .turbo cache folder.

Build:
- Add TurboRepo pipeline configuration

Chores:
- Ignore .turbo cache folder in .gitignore