### PR TITLE
feat: add React state machine hook

### DIFF
--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -7,3 +7,5 @@ Shared utility functions for the monorepo.
 - `cn` – class name merging helper.
 - `state-machine` – lightweight finite state machine creator with optional
   change callback.
+- `use-state-machine` – React hook that binds the state machine to component
+  state.

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -10,8 +10,16 @@
     "lint": "eslint 'src/**/*.{ts,tsx}'",
     "test": "vitest run"
   },
+  "peerDependencies": {
+    "react": "^19",
+    "react-dom": "^19"
+  },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@testing-library/jest-dom": "^6.6.4",
+    "@testing-library/react": "^16.3.0",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
     "eslint": "^9",
     "typescript": "^5",
     "vitest": "^3.2.4",

--- a/packages/utils/src/__tests__/use-state-machine.test.tsx
+++ b/packages/utils/src/__tests__/use-state-machine.test.tsx
@@ -1,0 +1,39 @@
+import { renderHook, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, it } from 'vitest';
+import { useStateMachine } from '../use-state-machine';
+
+const config = {
+  initial: 'idle',
+  transitions: {
+    idle: { start: 'running' },
+    running: { finish: 'done' },
+    done: {},
+  },
+} as const;
+
+describe('useStateMachine', () => {
+  it('transitions and re-renders', () => {
+    const { result } = renderHook(() => useStateMachine(config));
+
+    expect(result.current.state).toBe('idle');
+    act(() => {
+      result.current.send('start');
+    });
+    expect(result.current.state).toBe('running');
+    act(() => {
+      result.current.send('finish');
+    });
+    expect(result.current.state).toBe('done');
+  });
+
+  it('checks if event is valid', () => {
+    const { result } = renderHook(() => useStateMachine(config));
+
+    expect(result.current.can('start')).toBe(true);
+    act(() => {
+      result.current.send('start');
+    });
+    expect(result.current.can('start')).toBe(false);
+  });
+});

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,2 +1,3 @@
 export * from './cn';
 export * from './state-machine';
+export * from './use-state-machine';

--- a/packages/utils/src/use-state-machine.ts
+++ b/packages/utils/src/use-state-machine.ts
@@ -1,0 +1,32 @@
+import { useReducer, useRef } from 'react';
+import {
+  createStateMachine,
+  type StateMachine,
+  type StateMachineConfig,
+} from './state-machine';
+
+/**
+ * React hook wrapping {@link createStateMachine}. It triggers a re-render when
+ * the state changes.
+ *
+ * @param config - Machine configuration.
+ * @returns A state machine instance bound to React.
+ */
+export function useStateMachine<S extends string, E extends string>(
+  config: StateMachineConfig<S, E>,
+): StateMachine<S, E> {
+  const [, forceUpdate] = useReducer((c) => c + 1, 0);
+  const machineRef = useRef<StateMachine<S, E> | null>(null);
+
+  if (!machineRef.current) {
+    machineRef.current = createStateMachine({
+      ...config,
+      onChange(next, prev) {
+        config.onChange?.(next, prev);
+        forceUpdate();
+      },
+    });
+  }
+
+  return machineRef.current;
+}


### PR DESCRIPTION
## Summary
- create `useStateMachine` React hook for state machines
- document new hook in utils README
- expose hook via utils package index
- add tests for the hook
- update utils peer and dev dependencies for React

Closes #1

------
https://chatgpt.com/codex/tasks/task_e_68887ab999dc8326beba33b807f328a1

## Summary by Sourcery

Introduce useStateMachine hook in the utils package with updated React dependencies, exported API, documentation, and tests

New Features:
- Add useStateMachine React hook to bind finite state machines to component state

Build:
- Update utils package peerDependencies and devDependencies to include React and related types

Documentation:
- Document the useStateMachine hook in the utils README

Tests:
- Add unit tests for useStateMachine hook behavior and event validity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new React hook for integrating state machines with component state.
  * The new hook is now available as part of the public API.

* **Documentation**
  * Updated the package documentation to describe the new React hook.

* **Tests**
  * Added tests to verify the behaviour of the new React hook.

* **Chores**
  * Added React 19 and ReactDOM 19 as peer dependencies.
  * Updated development dependencies to support React 19 testing and type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->