### PR TITLE
feat: add GameClient component

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,6 +28,7 @@
     "jsdom": "^26.1.0",
     "tailwindcss": "^4",
     "typescript": "^5",
+    "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.2.4"
   }
 }

--- a/apps/web/src/components/GameClient.stories.tsx
+++ b/apps/web/src/components/GameClient.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { GameClient } from './GameClient';
+
+const meta: Meta<typeof GameClient> = {
+  title: 'Components/GameClient',
+  component: GameClient,
+  args: {
+    'aria-label': 'Game client demo',
+  },
+};
+
+export default meta;
+export type Story = StoryObj<typeof GameClient>;
+
+export const Default: Story = {};

--- a/apps/web/src/components/GameClient.tsx
+++ b/apps/web/src/components/GameClient.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Button } from '@ui/components/Button';
+import { cn } from '@utils/cn';
+import { createStateMachine } from '@utils/state-machine';
+
+/**
+ * Interactive client component controlling basic game flow.
+ */
+export type GameClientProps = React.HTMLAttributes<HTMLElement>;
+
+export function GameClient({ className, ...props }: GameClientProps) {
+  type S = 'intro' | 'playing' | 'completed';
+  type E = 'start' | 'finish' | 'reset';
+
+  const [machine] = useState(() =>
+    createStateMachine<S, E>({
+      initial: 'intro',
+      transitions: {
+        intro: { start: 'playing' },
+        playing: { finish: 'completed' },
+        completed: { reset: 'intro' },
+      },
+    }),
+  );
+
+  const [state, setState] = useState<S>(machine.state);
+
+  const handle = (event: E) => {
+    setState(machine.send(event));
+  };
+
+  return (
+    <section
+      className={cn('flex flex-col items-center gap-4 py-8', className)}
+      {...props}
+    >
+      {state === 'intro' && <p>Press start to play 🎮</p>}
+      {state === 'playing' && <p>Playing…</p>}
+      {state === 'completed' && <p>Game over 🎉</p>}
+      <div>
+        {state === 'intro' && (
+          <Button label="Start" onClick={() => handle('start')} />
+        )}
+        {state === 'playing' && (
+          <Button label="Finish" onClick={() => handle('finish')} />
+        )}
+        {state === 'completed' && (
+          <Button label="Reset" onClick={() => handle('reset')} />
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/__tests__/GameClient.test.tsx
+++ b/apps/web/src/components/__tests__/GameClient.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { GameClient } from '../GameClient';
+
+describe('GameClient', () => {
+  it('progresses through the game states', () => {
+    const { getByRole, getByText } = render(<GameClient />);
+
+    // intro state
+    expect(getByText(/press start/i)).toBeInTheDocument();
+    const start = getByRole('button', { name: /start/i });
+    fireEvent.click(start);
+
+    // playing state
+    expect(getByText(/playing/i)).toBeInTheDocument();
+    const finish = getByRole('button', { name: /finish/i });
+    fireEvent.click(finish);
+
+    // completed state
+    expect(getByText(/game over/i)).toBeInTheDocument();
+    const reset = getByRole('button', { name: /reset/i });
+    fireEvent.click(reset);
+
+    // back to intro
+    expect(getByText(/press start/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/types/storybook.d.ts
+++ b/apps/web/src/types/storybook.d.ts
@@ -1,0 +1,4 @@
+declare module '@storybook/react' {
+  export type Meta<T> = Record<string, unknown>;
+  export type StoryObj<T> = Record<string, unknown>;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,17 @@
 import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
+import { resolve } from 'path';
 
 export default defineConfig({
+  plugins: [
+    tsconfigPaths({
+      projects: [
+        resolve(__dirname, 'apps/web/tsconfig.json'),
+        resolve(__dirname, 'packages/ui/tsconfig.json'),
+        resolve(__dirname, 'packages/utils/tsconfig.json'),
+      ],
+    }),
+  ],
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- create interactive GameClient component
- add storybook stub
- cover with unit tests
- enable tsconfig paths for Vitest

Closes #1

------
https://chatgpt.com/codex/tasks/task_e_688886cf4a988326b76ea03a292bb0c0