### PR TITLE
Expose game client on homepage

### DIFF
--- a/apps/web/src/app/__tests__/HomePage.test.tsx
+++ b/apps/web/src/app/__tests__/HomePage.test.tsx
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import HomePage from '../page';
+
+describe('HomePage', () => {
+  it('renders the game client', () => {
+    const { getByLabelText } = render(<HomePage />);
+    const client = getByLabelText(/demo game client/i);
+    expect(client).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,14 +1,16 @@
 import Image from 'next/image';
 import React from 'react';
+import { GameClient } from '../components/GameClient';
 import { HomeHero } from '../components/HomeHero';
 
 /**
- * Home page displaying the hero section.
+ * Home page with the hero section and game client.
  */
 export default function HomePage() {
   return (
     <main className="mx-auto max-w-3xl p-4">
       <HomeHero />
+      <GameClient className="mt-4" aria-label="Demo game client" />
       <div className="mt-10 flex justify-center">
         <Image
           className="dark:invert"


### PR DESCRIPTION
## Summary
- show GameClient component on the home page
- add test for HomePage to verify GameClient rendering

Closes #17

------
https://chatgpt.com/codex/tasks/task_e_688895a179b0832693aa9ca0f9352127

## Summary by Sourcery

Expose the GameClient component on the homepage and ensure its rendering is covered by a new test.

New Features:
- Render GameClient component on the home page

Tests:
- Add HomePage test to verify GameClient renders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a demo game client to the home page, accessible below the hero section.

* **Tests**
  * Introduced a new test to verify the presence of the demo game client on the home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->