### PR TITLE
feat(ui): add href prop

### DIFF
--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -1,5 +1,7 @@
-import Link from 'next/link';
+'use client';
+
 import React from 'react';
+import { Button } from '@ui/components/Button';
 
 /**
  * Hero section displayed on the home page.
@@ -11,12 +13,11 @@ export function HomeHero() {
       <p className="text-lg text-gray-600 dark:text-gray-400">
         A replay-friendly, text-first investigation game.
       </p>
-      <Link
+      <Button
         href="/"
-        className="rounded-full bg-foreground px-5 py-2 font-medium text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc]"
-      >
-        Start Exploring 🚀
-      </Link>
+        label="Start Exploring 🚀"
+        className="rounded-full px-5 py-2 font-medium"
+      />
     </section>
   );
 }

--- a/packages/ui/src/__tests__/Button.test.tsx
+++ b/packages/ui/src/__tests__/Button.test.tsx
@@ -10,4 +10,12 @@ describe('Button', () => {
     const button = getByRole('button', { name: /click me/i });
     expect(button).toBeInTheDocument();
   });
+
+  it('renders an anchor when href provided', () => {
+    const { getByRole } = render(
+      <Button label="Start" href="/foo" />,
+    );
+    const link = getByRole('link', { name: /start/i });
+    expect(link).toHaveAttribute('href', '/foo');
+  });
 });

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,22 +1,38 @@
 import React from 'react';
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  /**
-   * Button label
-   */
+export type AnchorProps = {
+  /** Button label */
   label: string;
-}
+  href: string;
+} & Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href' | 'children'>;
+
+export type NativeButtonProps = {
+  /** Button label */
+  label: string;
+  href?: undefined;
+} & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children'>;
+
+export type ButtonProps = AnchorProps | NativeButtonProps;
 
 /**
  * Primary button component.
  */
-export function Button({ label, className, ...props }: ButtonProps) {
+export function Button(props: ButtonProps) {
+  const { label, className } = props;
+  const classes = `rounded bg-foreground px-4 py-2 text-background hover:opacity-90 ${className ?? ''}`;
+
+  if ('href' in props && props.href) {
+    const { href, ...anchorProps } = props;
+    return (
+      <a href={href} className={classes} {...anchorProps}>
+        {label}
+      </a>
+    );
+  }
+
+  const buttonProps = props as NativeButtonProps;
   return (
-    <button
-      type="button"
-      className={`rounded bg-foreground px-4 py-2 text-background hover:opacity-90 ${className ?? ''}`}
-      {...props}
-    >
+    <button type="button" className={classes} {...buttonProps}>
       {label}
     </button>
   );


### PR DESCRIPTION
## Summary
- allow Button component to render as anchor when `href` provided
- use the href-enabled Button in HomeHero
- clean up tests after router removal

Closes #18

## Testing
- `yarn lint:fix`
- `yarn test`
- `git secrets --scan`
- `yarn web:ci`


------
https://chatgpt.com/codex/tasks/task_e_6888a5e91e7483268baa01531596a1e3

## Summary by Sourcery

Enable the Button component to accept an href prop and render as an anchor, update HomeHero to use the new API, and adjust tests accordingly.

New Features:
- Allow Button to render as an <a> element when an href prop is provided
- Replace HomeHero’s Link with the href-enabled Button component

Enhancements:
- Extract shared className logic into a single variable for both button and anchor

Tests:
- Add a test to verify Button renders an anchor with the correct href when provided

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Button component now supports rendering as a link when provided with a URL, improving navigation options.
* **Refactor**
  * Updated HomeHero to use the enhanced Button component for navigation.
  * Improved Button component prop types for clearer usage and better type safety.
* **Tests**
  * Added a test to verify Button renders correctly as a link when given a URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->