### PR TITLE
feat: add game migration

### DIFF
--- a/supabase/migrations/20250730060105_create_game_table.sql
+++ b/supabase/migrations/20250730060105_create_game_table.sql
@@ -1,0 +1,25 @@
+-- Migration: Create game table
+-- Creates a table to persist game sessions.
+
+create extension if not exists "uuid-ossp";
+
+create table if not exists public.game (
+  id uuid primary key default uuid_generate_v4(),
+  inserted_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  name text not null,
+  state jsonb not null default '{}'::jsonb
+);
+
+create or replace function public.update_timestamp()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger game_update_timestamp
+before update on public.game
+for each row
+execute procedure public.update_timestamp();


### PR DESCRIPTION
## Summary
- create game table migration

Closes #123

------
https://chatgpt.com/codex/tasks/task_e_6889b47ad8bc8326aa8888425df90bf7

## Summary by Sourcery

Add migration to create game sessions table with UUID primary keys, timestamps, name, and JSON state, and define a trigger to auto-update the updated_at field

Enhancements:
- Add supabase migration SQL to define public.game table with id, inserted_at, updated_at, name, and JSONB state columns
- Enable uuid-ossp extension and add a trigger function to update the updated_at timestamp on row updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for storing and managing game session data, including automatic tracking of creation and update times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->