### PR TITLE
feat(utils): add typed supabase client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Supabase connection settings
+NEXT_PUBLIC_SUPABASE_URL="https://your-project.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="YOUR_ANON_KEY"

--- a/packages/utils/eslint.config.mjs
+++ b/packages/utils/eslint.config.mjs
@@ -13,4 +13,14 @@ const compat = new FlatCompat({
 export default [
   ...baseConfig,
   ...compat.extends('next/core-web-vitals', 'next/typescript'),
+  {
+    settings: {
+      next: {
+        rootDir: __dirname,
+      },
+    },
+    rules: {
+      'next/no-html-link-for-pages': 'off',
+    },
+  },
 ];

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "eslint 'src/**/*.{ts,tsx}'",
@@ -13,11 +15,12 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "eslint": "^9",
+    "jsdom": "^26.1.0",
     "typescript": "^5",
-    "vitest": "^3.2.4",
-    "jsdom": "^26.1.0"
+    "vitest": "^3.2.4"
   },
   "dependencies": {
+    "@supabase/supabase-js": "2.39.3",
     "clsx": "^2",
     "tailwind-merge": "^2"
   }

--- a/packages/utils/src/__tests__/supabase.test.ts
+++ b/packages/utils/src/__tests__/supabase.test.ts
@@ -1,0 +1,24 @@
+import { vi } from 'vitest';
+import { createClient } from '@supabase/supabase-js';
+import { createSupabaseClient } from '../supabase';
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({ url: 'mock', key: 'mock' })),
+}));
+
+describe('createSupabaseClient', () => {
+  it('initialises the client with env vars', () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://db.test';
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'key';
+
+    createSupabaseClient();
+
+    expect(createClient).toHaveBeenCalledWith('https://db.test', 'key');
+  });
+
+  it('throws when env vars are missing', () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    expect(() => createSupabaseClient()).toThrow('Supabase credentials are missing');
+  });
+});

--- a/packages/utils/src/database.types.ts
+++ b/packages/utils/src/database.types.ts
@@ -1,0 +1,40 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json }
+  | Json[];
+
+export interface Database {
+  public: {
+    Tables: {
+      game: {
+        Row: {
+          id: string;
+          inserted_at: string;
+          updated_at: string;
+          name: string;
+          state: Json;
+          user_id: string;
+        };
+        Insert: {
+          id?: string;
+          inserted_at?: string;
+          updated_at?: string;
+          name: string;
+          state?: Json;
+          user_id?: string;
+        };
+        Update: {
+          id?: string;
+          inserted_at?: string;
+          updated_at?: string;
+          name?: string;
+          state?: Json;
+          user_id?: string;
+        };
+      };
+    };
+  };
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,2 +1,4 @@
 export * from './cn';
 export * from './state-machine';
+export * from './supabase';
+export * from './database.types';

--- a/packages/utils/src/supabase.ts
+++ b/packages/utils/src/supabase.ts
@@ -1,0 +1,19 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+import type { Database } from './database.types';
+
+/**
+ * Create a type-safe Supabase client.
+ *
+ * @returns A Supabase client instance.
+ */
+export function createSupabaseClient(): SupabaseClient<Database> {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
+
+  if (!url || !key) {
+    throw new Error('Supabase credentials are missing');
+  }
+
+  return createClient<Database>(url, key);
+}


### PR DESCRIPTION
## Summary
- add supabase environment example
- implement typed supabase client in utils package
- expose new helper and database types
- configure utils ESLint for Next plugin
- test supabase client creation

Closes #21

------
https://chatgpt.com/codex/tasks/task_e_6889c49c81308326bab594bdff1c4ef6