### PR TITLE
feat(web): add server actions for games

### DIFF
--- a/apps/web/src/app/__tests__/gameActions.test.ts
+++ b/apps/web/src/app/__tests__/gameActions.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+const __mock = { from: vi.fn() };
+vi.mock('@utils/supabase', () => ({ createSupabaseClient: () => ({ from: __mock.from }) }));
+import { createGame, getGame, updateGameState } from "../_actions/game";
+
+
+const mockGame = {
+  id: '1',
+  inserted_at: '',
+  updated_at: '',
+  name: 'Test',
+  state: {},
+  user_id: 'u',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('game server actions', () => {
+  it('creates a new game', async () => {
+    const single = vi.fn().mockResolvedValue({ data: mockGame, error: null });
+    const select = vi.fn(() => ({ single }));
+    const insert = vi.fn(() => ({ select }));
+    __mock.from.mockReturnValue({ insert });
+
+    const result = await createGame('Test');
+
+    expect(__mock.from).toHaveBeenCalledWith('game');
+    expect(insert).toHaveBeenCalledWith({ name: 'Test' });
+    expect(result).toEqual(mockGame);
+  });
+
+  it('retrieves a game by id', async () => {
+    const single = vi.fn().mockResolvedValue({ data: mockGame, error: null });
+    const eq = vi.fn(() => ({ single }));
+    const select = vi.fn(() => ({ eq }));
+    __mock.from.mockReturnValue({ select });
+
+    const result = await getGame('1');
+
+    expect(__mock.from).toHaveBeenCalledWith('game');
+    expect(select).toHaveBeenCalledWith('*');
+    expect(eq).toHaveBeenCalledWith('id', '1');
+    expect(result).toEqual(mockGame);
+  });
+
+  it('updates game state', async () => {
+    const eq = vi.fn().mockResolvedValue({ error: null });
+    const update = vi.fn(() => ({ eq }));
+    __mock.from.mockReturnValue({ update });
+
+    await updateGameState('1', { foo: true });
+
+    expect(__mock.from).toHaveBeenCalledWith('game');
+    expect(update).toHaveBeenCalledWith({ state: { foo: true } });
+    expect(eq).toHaveBeenCalledWith('id', '1');
+  });
+});

--- a/apps/web/src/app/_actions/game.ts
+++ b/apps/web/src/app/_actions/game.ts
@@ -1,0 +1,61 @@
+'use server';
+
+import { createSupabaseClient } from '@utils/supabase';
+import type { Database } from '@utils/database.types';
+
+export type GameRow = Database['public']['Tables']['game']['Row'];
+
+/**
+ * Persist a new game.
+ *
+ * @param name - Game name.
+ * @returns Created game row.
+ */
+export async function createGame(name: string): Promise<GameRow> {
+  const supabase = createSupabaseClient();
+  const { data, error } = await supabase
+    .from('game')
+    .insert({ name })
+    .select('*')
+    .single();
+
+  if (error) throw new Error(error.message);
+  return data as GameRow;
+}
+
+/**
+ * Fetch a game by id.
+ *
+ * @param id - Game identifier.
+ * @returns The requested game row.
+ */
+export async function getGame(id: string): Promise<GameRow> {
+  const supabase = createSupabaseClient();
+  const { data, error } = await supabase
+    .from('game')
+    .select('*')
+    .eq('id', id)
+    .single();
+
+  if (error) throw new Error(error.message);
+  return data as GameRow;
+}
+
+/**
+ * Update a game's state.
+ *
+ * @param id - Game identifier.
+ * @param state - New state.
+ */
+export async function updateGameState(
+  id: string,
+  state: GameRow['state'],
+): Promise<void> {
+  const supabase = createSupabaseClient();
+  const { error } = await supabase
+    .from('game')
+    .update({ state })
+    .eq('id', id);
+
+  if (error) throw new Error(error.message);
+}


### PR DESCRIPTION
## Summary
- add game server actions with Supabase calls
- test the game server actions

Closes #1

------
https://chatgpt.com/codex/tasks/task_e_6889ef7d0ac08326a879b2b12177ebf8