### PR TITLE
feat(web): add skip link

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,8 +1,11 @@
-import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
-import { Header } from "../components/Header";
-import React from "react";
-import "./globals.css";
+import type { Metadata } from 'next';
+import { Geist, Geist_Mono } from 'next/font/google';
+import React from 'react';
+
+import { Header } from '../components/Header';
+import { SkipLink } from '../components/SkipLink';
+
+import './globals.css';
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -33,6 +36,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <React.StrictMode>
+          <SkipLink />
           <Header />
           {children}
         </React.StrictMode>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -8,7 +8,7 @@ import { HomeHero } from '../components/HomeHero';
  */
 export default function HomePage() {
   return (
-    <main className="mx-auto max-w-3xl p-4">
+    <main id="story" className="mx-auto max-w-3xl p-4" tabIndex={-1}>
       <HomeHero />
       <GameClient className="mt-4" aria-label="Demo game client" />
       <div className="mt-10 flex justify-center">

--- a/apps/web/src/components/SkipLink.stories.tsx
+++ b/apps/web/src/components/SkipLink.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { SkipLink } from './SkipLink';
+
+const meta: Meta<React.ComponentProps<typeof SkipLink>> = {
+  title: 'Components/SkipLink',
+  component: SkipLink,
+  args: { 'aria-label': 'Skip navigation' },
+};
+
+export default meta;
+export type Story = StoryObj<typeof SkipLink>;
+
+export const Default: Story = {};

--- a/apps/web/src/components/SkipLink.tsx
+++ b/apps/web/src/components/SkipLink.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { cn } from '@utils/cn';
+
+/**
+ * Hidden skip link for keyboard navigation to the main story.
+ */
+export type SkipLinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+  /**
+   * Where to skip to.
+   * @default '#story'
+   */
+  href?: string;
+};
+
+export function SkipLink({ className, href = '#story', ...props }: SkipLinkProps) {
+  return (
+    <a
+      {...props}
+      href={href}
+      className={cn(
+        'absolute left-[-999px] top-auto h-px w-px overflow-hidden focus:left-2 focus:top-2 focus:h-auto focus:w-auto focus:bg-foreground focus:text-background focus:p-2',
+        className,
+      )}
+    >
+      Skip to story 📖
+    </a>
+  );
+}

--- a/apps/web/src/components/__tests__/SkipLink.test.tsx
+++ b/apps/web/src/components/__tests__/SkipLink.test.tsx
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { SkipLink } from '../SkipLink';
+
+describe('SkipLink', () => {
+  it('renders with default href', () => {
+    const { getByRole } = render(<SkipLink />);
+    const link = getByRole('link', { name: /skip to story/i });
+    expect(link).toHaveAttribute('href', '#story');
+  });
+});


### PR DESCRIPTION
## Summary
- add `<SkipLink>` component for keyboard users
- expose storybook story
- render skip link in `layout`
- mark main region with `id="story"`
- test skip link

Closes #123

------
https://chatgpt.com/codex/tasks/task_e_688b1672896c83269cc6e9619233f33d

## Summary by Sourcery

Introduce a SkipLink component to enable keyboard users to bypass navigation and jump directly to the main content.

New Features:
- Add SkipLink component for keyboard navigation with customizable target
- Render SkipLink at the top of the global layout
- Assign id="story" and tabIndex=-1 to the main content container to serve as the skip target
- Expose SkipLink in Storybook with a default story

Tests:
- Add unit tests for the SkipLink component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a SkipLink component to improve keyboard navigation and accessibility, allowing users to quickly jump to the main story content.
* **Accessibility**
  * Added an accessible skip link before the header and assigned an ID and tabIndex to the main content container for improved navigation.
* **Tests**
  * Added tests to verify the correct rendering and functionality of the SkipLink component.
* **Documentation**
  * Added a Storybook story for the new SkipLink component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->