### PR TITLE
fix(web): update landmark roles

### DIFF
--- a/apps/web/src/app/__tests__/HomePage.test.tsx
+++ b/apps/web/src/app/__tests__/HomePage.test.tsx
@@ -6,8 +6,10 @@ import HomePage from '../page';
 
 describe('HomePage', () => {
   it('renders the game client', () => {
-    const { getByLabelText } = render(<HomePage />);
+    const { getByLabelText, getByRole } = render(<HomePage />);
+    const main = getByRole('main');
     const client = getByLabelText(/demo game client/i);
     expect(client).toBeInTheDocument();
+    expect(main).toContainElement(client);
   });
 });

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -8,7 +8,7 @@ import { HomeHero } from '../components/HomeHero';
  */
 export default function HomePage() {
   return (
-    <main id="story" className="mx-auto max-w-3xl p-4" tabIndex={-1}>
+    <main id="story" role="main" className="mx-auto max-w-3xl p-4" tabIndex={-1}>
       <HomeHero />
       <GameClient className="mt-4" aria-label="Demo game client" />
       <div className="mt-10 flex justify-center">

--- a/apps/web/src/components/GameClient.tsx
+++ b/apps/web/src/components/GameClient.tsx
@@ -36,6 +36,7 @@ export function GameClient({ className, ...props }: GameClientProps) {
 
   return (
     <section
+      role="region"
       className={cn('flex flex-col items-center gap-4 py-8', className)}
       {...props}
     >

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -6,8 +6,14 @@ import React from 'react';
  */
 export function Header() {
   return (
-    <header className="border-b border-gray-200 dark:border-gray-800 py-4">
-      <nav className="mx-auto flex max-w-4xl items-center justify-between px-4">
+    <header
+      role="banner"
+      className="border-b border-gray-200 dark:border-gray-800 py-4"
+    >
+      <nav
+        role="navigation"
+        className="mx-auto flex max-w-4xl items-center justify-between px-4"
+      >
         <Link href="/" className="text-xl font-semibold">
           Echoes of Control
         </Link>

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -8,7 +8,11 @@ import { Button } from '@ui/components/Button';
  */
 export function HomeHero() {
   return (
-    <section className="flex flex-col items-center gap-6 py-16 text-center">
+    <section
+      role="region"
+      aria-label="Welcome section"
+      className="flex flex-col items-center gap-6 py-16 text-center"
+    >
       <h1 className="text-4xl font-bold">Welcome to Echoes of Control</h1>
       <p className="text-lg text-gray-600 dark:text-gray-400">
         A replay-friendly, text-first investigation game.

--- a/apps/web/src/components/__tests__/GameClient.test.tsx
+++ b/apps/web/src/components/__tests__/GameClient.test.tsx
@@ -7,6 +7,8 @@ import { GameClient } from '../GameClient';
 describe('GameClient', () => {
   it('progresses through the game states', () => {
     const { getByRole, getByText } = render(<GameClient />);
+    const region = getByRole('region');
+    expect(region).toBeInTheDocument();
 
     // intro state
     expect(getByText(/press start/i)).toBeInTheDocument();

--- a/apps/web/src/components/__tests__/Header.test.tsx
+++ b/apps/web/src/components/__tests__/Header.test.tsx
@@ -7,7 +7,10 @@ import '@testing-library/jest-dom';
 describe('Header', () => {
   it('renders a link to the homepage', () => {
     const { getByRole } = render(<Header />);
+    const banner = getByRole('banner');
+    const navigation = getByRole('navigation');
     const link = getByRole('link', { name: /echoes of control/i });
     expect(link).toHaveAttribute('href', '/');
+    expect(banner).toContainElement(navigation);
   });
 });

--- a/apps/web/src/components/__tests__/HomeHero.test.tsx
+++ b/apps/web/src/components/__tests__/HomeHero.test.tsx
@@ -7,8 +7,9 @@ import { HomeHero } from '../HomeHero';
 describe('HomeHero', () => {
   it('shows the welcome heading', () => {
     const { getByRole } = render(<HomeHero />);
+    const region = getByRole('region', { name: /welcome section/i });
     const heading = getByRole('heading', { name: /welcome to echoes of control/i });
-    expect(heading).toBeInTheDocument();
+    expect(region).toContainElement(heading);
   });
 
   it('links to start exploring', () => {


### PR DESCRIPTION
## Summary
- improve semantics for landmark elements
- verify accessibility roles in component tests

Closes #36

------
https://chatgpt.com/codex/tasks/task_e_688b1a2dd9508326b42e2fe7a82ac462

## Summary by Sourcery

Add ARIA landmark roles to various components and update tests to verify accessibility semantics

Enhancements:
- Add role="banner" to the Header component and role="navigation" to its nav element
- Add role="main" to the main element in HomePage
- Add role="region" and appropriate aria-label to HomeHero and GameClient sections

Tests:
- Update HomePage test to check for the main role and its containment of the game client
- Update Header test to assert banner and navigation roles and their hierarchy
- Update HomeHero test to assert the region role and its containment of the heading
- Update GameClient test to assert the region role presence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved accessibility by adding explicit ARIA roles and labels to main content, header, navigation, and section elements across key components.

* **Tests**
  * Enhanced component tests to verify the presence and correct hierarchical relationships of accessibility landmarks and regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->