### PR TITLE
feat(web): auto focus new buttons

### DIFF
--- a/apps/web/src/components/GameClient.tsx
+++ b/apps/web/src/components/GameClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Button } from '@ui/components/Button';
 import { cn } from '@utils/cn';
 import { createStateMachine } from '@utils/state-machine';
@@ -29,6 +29,11 @@ export function GameClient({ className, ...props }: GameClientProps) {
   );
 
   const [state, setState] = useState<S>(machineRef.current.state);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    buttonRef.current?.focus();
+  }, [state]);
 
   const handle = (event: E) => {
     setState(machineRef.current.send(event));
@@ -45,13 +50,28 @@ export function GameClient({ className, ...props }: GameClientProps) {
       {state === 'completed' && <p>Game over 🎉</p>}
       <div>
         {state === 'intro' && (
-          <Button label="Start" onClick={() => handle('start')} />
+          <Button
+            ref={buttonRef}
+            autoFocus
+            label="Start"
+            onClick={() => handle('start')}
+          />
         )}
         {state === 'playing' && (
-          <Button label="Finish" onClick={() => handle('finish')} />
+          <Button
+            ref={buttonRef}
+            autoFocus
+            label="Finish"
+            onClick={() => handle('finish')}
+          />
         )}
         {state === 'completed' && (
-          <Button label="Reset" onClick={() => handle('reset')} />
+          <Button
+            ref={buttonRef}
+            autoFocus
+            label="Reset"
+            onClick={() => handle('reset')}
+          />
         )}
       </div>
     </section>

--- a/apps/web/src/components/__tests__/GameClient.test.tsx
+++ b/apps/web/src/components/__tests__/GameClient.test.tsx
@@ -28,4 +28,19 @@ describe('GameClient', () => {
     // back to intro
     expect(getByText(/press start/i)).toBeInTheDocument();
   });
+
+  it('focuses new button when state changes', () => {
+    const { getByRole } = render(<GameClient />);
+
+    const start = getByRole('button', { name: /start/i });
+    expect(start).toHaveFocus();
+    fireEvent.click(start);
+
+    const finish = getByRole('button', { name: /finish/i });
+    expect(finish).toHaveFocus();
+    fireEvent.click(finish);
+
+    const reset = getByRole('button', { name: /reset/i });
+    expect(reset).toHaveFocus();
+  });
 });

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -17,14 +17,17 @@ export type ButtonProps = AnchorProps | NativeButtonProps;
 /**
  * Primary button component.
  */
-export function Button(props: ButtonProps) {
+export const Button = React.forwardRef<
+  HTMLAnchorElement | HTMLButtonElement,
+  ButtonProps
+>(function Button(props, ref) {
   const { label, className } = props;
   const classes = `rounded bg-foreground px-4 py-2 text-background hover:opacity-90 ${className ?? ''}`;
 
   if ('href' in props && props.href) {
     const { href, ...anchorProps } = props;
     return (
-      <a href={href} className={classes} {...anchorProps}>
+      <a ref={ref as React.Ref<HTMLAnchorElement>} href={href} className={classes} {...anchorProps}>
         {label}
       </a>
     );
@@ -32,8 +35,13 @@ export function Button(props: ButtonProps) {
 
   const buttonProps = props as NativeButtonProps;
   return (
-    <button type="button" className={classes} {...buttonProps}>
+    <button
+      ref={ref as React.Ref<HTMLButtonElement>}
+      type="button"
+      className={classes}
+      {...buttonProps}
+    >
       {label}
     </button>
   );
-}
+});


### PR DESCRIPTION
## Summary
- auto focus new action buttons in `GameClient`
- forward refs in `Button` component
- verify button focus in `GameClient` tests

Closes #45

------
https://chatgpt.com/codex/tasks/task_e_688b6cc3ee308326b17364a5ffe109dc