### PR TITLE
feat(web): announce story updates

### DIFF
--- a/apps/web/src/components/GameClient.tsx
+++ b/apps/web/src/components/GameClient.tsx
@@ -29,6 +29,11 @@ export function GameClient({ className, ...props }: GameClientProps) {
   );
 
   const [state, setState] = useState<S>(machineRef.current.state);
+  const messages: Record<S, string> = {
+    intro: 'Press start to play 🎮',
+    playing: 'Playing…',
+    completed: 'Game over 🎉',
+  };
   const buttonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
@@ -45,9 +50,7 @@ export function GameClient({ className, ...props }: GameClientProps) {
       className={cn('flex flex-col items-center gap-4 py-8', className)}
       {...props}
     >
-      {state === 'intro' && <p>Press start to play 🎮</p>}
-      {state === 'playing' && <p>Playing…</p>}
-      {state === 'completed' && <p>Game over 🎉</p>}
+      <p aria-live="polite" aria-atomic="true">{messages[state]}</p>
       <div>
         {state === 'intro' && (
           <Button

--- a/apps/web/src/components/__tests__/GameClient.test.tsx
+++ b/apps/web/src/components/__tests__/GameClient.test.tsx
@@ -9,6 +9,7 @@ describe('GameClient', () => {
     const { getByRole, getByText } = render(<GameClient />);
     const region = getByRole('region');
     expect(region).toBeInTheDocument();
+    expect(region.firstChild).toHaveAttribute('aria-live', 'polite');
 
     // intro state
     expect(getByText(/press start/i)).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- add aria-live region for story messages
- test aria-live attribute is present

Closes #40

------
https://chatgpt.com/codex/tasks/task_e_688b71bede3c8326a8beb92b712470a8

## Summary by Sourcery

Introduce an aria-live region in the GameClient component to announce dynamic game state messages for improved accessibility and update tests accordingly

New Features:
- Render all game state messages inside a single <p> element with aria-live="polite" and aria-atomic="true" instead of conditional paragraphs

Tests:
- Add a test to assert that the live region has the aria-live attribute set to 'polite'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the display of game state messages into a single, dynamically rendered paragraph for improved maintainability and accessibility.
* **Tests**
  * Enhanced tests to verify the presence and correct value of accessibility attributes related to live region announcements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->