### PR TITLE
feat(web): label navigation landmarks

### DIFF
--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -8,10 +8,12 @@ export function Header() {
   return (
     <header
       role="banner"
+      aria-label="Site banner"
       className="border-b border-gray-200 dark:border-gray-800 py-4"
     >
       <nav
         role="navigation"
+        aria-label="Primary navigation"
         className="mx-auto flex max-w-4xl items-center justify-between px-4"
       >
         <Link href="/" className="text-xl font-semibold">

--- a/apps/web/src/components/__tests__/Header.test.tsx
+++ b/apps/web/src/components/__tests__/Header.test.tsx
@@ -7,8 +7,8 @@ import '@testing-library/jest-dom';
 describe('Header', () => {
   it('renders a link to the homepage', () => {
     const { getByRole } = render(<Header />);
-    const banner = getByRole('banner');
-    const navigation = getByRole('navigation');
+    const banner = getByRole('banner', { name: /site banner/i });
+    const navigation = getByRole('navigation', { name: /primary navigation/i });
     const link = getByRole('link', { name: /echoes of control/i });
     expect(link).toHaveAttribute('href', '/');
     expect(banner).toContainElement(navigation);


### PR DESCRIPTION
## Summary
- add accessible `aria-label`s to the header landmarks
- verify header test covers labelled roles

Closes #35

------
https://chatgpt.com/codex/tasks/task_e_688c6617677c8326be69e4571e7e222d

## Summary by Sourcery

Add accessible labels to header role landmarks and adjust tests to verify the labelled roles.

New Features:
- Add aria-label attributes to the header (banner) and navigation landmarks for accessibility

Tests:
- Update Header component tests to query the banner and navigation roles by their accessible names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved accessibility of the header and navigation by adding ARIA labels for better screen reader support.

* **Tests**
  * Updated tests to use more specific queries for accessible names, ensuring accurate validation of ARIA labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->