### PR TITLE
feat(ui): add useStoryClient hook

### DIFF
--- a/packages/ui/src/__tests__/useStoryClient.test.tsx
+++ b/packages/ui/src/__tests__/useStoryClient.test.tsx
@@ -1,0 +1,39 @@
+import { act, renderHook } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, it } from 'vitest';
+import { useStoryClient } from '../hooks/useStoryClient';
+
+function* demoStory() {
+  const name: string = yield 'ask-name';
+  yield `hello-${name}`;
+}
+
+describe('useStoryClient', () => {
+  it('steps through a story', () => {
+    const { result } = renderHook(() => useStoryClient(demoStory));
+
+    act(() => {
+      result.current.step();
+    });
+    expect(result.current.current).toBe('ask-name');
+    expect(result.current.done).toBe(false);
+
+    act(() => {
+      result.current.step('sam');
+    });
+    expect(result.current.current).toBe('hello-sam');
+    expect(result.current.done).toBe(false);
+
+    act(() => {
+      result.current.step();
+    });
+    expect(result.current.current).toBeUndefined();
+    expect(result.current.done).toBe(true);
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.current).toBeUndefined();
+    expect(result.current.done).toBe(false);
+  });
+});

--- a/packages/ui/src/hooks/useStoryClient.ts
+++ b/packages/ui/src/hooks/useStoryClient.ts
@@ -1,0 +1,61 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { StoryRunner } from '@utils/story-runner';
+import { createStoryRunner } from '@utils/story-runner';
+
+export interface UseStoryClientReturn<TInput, TOutput> {
+  /** Current value from the story. */
+  current?: TOutput;
+  /** Whether the story has finished. */
+  done: boolean;
+  /** Advance the story by one step. */
+  step: (input?: TInput) => void;
+  /** Reset the story to the beginning. */
+  reset: () => void;
+}
+
+/**
+ * React hook for running generator-based stories on the client.
+ *
+ * Provides the current value and helper methods to step through or
+ * reset the story. The hook recreates the runner when the factory
+ * reference changes.
+ *
+ * @param factory - Function returning a story generator.
+ * @returns Control functions and current story state.
+ */
+export function useStoryClient<TInput = unknown, TOutput = unknown>(
+  factory: () => Generator<TOutput, void, TInput>,
+): UseStoryClientReturn<TInput, TOutput> {
+  const runnerRef = useRef<StoryRunner<TInput, TOutput> | null>(null);
+  const [current, setCurrent] = useState<TOutput>();
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    runnerRef.current = createStoryRunner(factory);
+    setCurrent(undefined);
+    setDone(false);
+  }, [factory]);
+
+  const step = useCallback((input?: TInput) => {
+    const result = runnerRef.current?.step(input);
+    if (!result) return;
+
+    if (result.done) {
+      setCurrent(undefined);
+      setDone(true);
+      return;
+    }
+
+    setCurrent(result.value);
+  }, []);
+
+  const reset = useCallback(() => {
+    runnerRef.current?.reset();
+    setCurrent(undefined);
+    setDone(false);
+  }, []);
+
+  return { current, done, step, reset };
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,1 +1,2 @@
 export * from './components/Button';
+export * from './hooks/useStoryClient';

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -10,7 +10,10 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "paths": {
+      "@utils/*": ["../utils/src/*"]
+    }
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- add `useStoryClient` hook for running generator stories
- export the hook via the ui package index
- expose utils path alias for ui
- test `useStoryClient`

## Testing
- `yarn lint:fix`
- `yarn test`
- `yarn web:ci`

------
https://chatgpt.com/codex/tasks/task_e_688ca94e58ac8326980c85f96f938c36

## Summary by Sourcery

Introduce a new useStoryClient hook in the UI package, configure path alias for utilities, expose the hook via the package index, and add corresponding tests.

New Features:
- Add useStoryClient hook for running generator-based stories on the client
- Expose useStoryClient hook in the UI package index
- Introduce @utils/* path alias in UI tsconfig for importing utilities

Tests:
- Add unit tests for useStoryClient hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new hook for managing interactive, generator-based stories within the UI.
* **Bug Fixes**
  * Not applicable.
* **Tests**
  * Added comprehensive tests to ensure correct behaviour of the new story management hook.
* **Chores**
  * Updated TypeScript configuration to support new path aliases.
* **Documentation**
  * Not applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->