### PR TITLE
feat(ui): add choice button component

### DIFF
--- a/apps/web/src/components/ChoiceButton.stories.tsx
+++ b/apps/web/src/components/ChoiceButton.stories.tsx
@@ -5,11 +5,11 @@ import { ChoiceButton } from '@ui/components/ChoiceButton';
 const meta: Meta<React.ComponentProps<typeof ChoiceButton>> = {
   title: 'Components/ChoiceButton',
   component: ChoiceButton,
-  args: { 'aria-label': 'Choice button example' },
+  args: { label: 'Example', 'aria-label': 'Choice button example' },
 };
 
 export default meta;
-export type Story = StoryObj<typeof ChoiceButton>;
+export type Story = StoryObj<React.ComponentProps<typeof ChoiceButton>>;
 
 export const Default: Story = {
   args: { label: 'Select me' },

--- a/apps/web/src/components/ChoiceButton.stories.tsx
+++ b/apps/web/src/components/ChoiceButton.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { ChoiceButton } from '@ui/components/ChoiceButton';
+
+const meta: Meta<React.ComponentProps<typeof ChoiceButton>> = {
+  title: 'Components/ChoiceButton',
+  component: ChoiceButton,
+  args: { 'aria-label': 'Choice button example' },
+};
+
+export default meta;
+export type Story = StoryObj<typeof ChoiceButton>;
+
+export const Default: Story = {
+  args: { label: 'Select me' },
+};

--- a/apps/web/src/components/GameClient.tsx
+++ b/apps/web/src/components/GameClient.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { Button } from '@ui/components/Button';
+import { ChoiceButton } from '@ui/components/ChoiceButton';
 import { cn } from '@utils/cn';
 import { createStateMachine } from '@utils/state-machine';
 
@@ -29,6 +30,7 @@ export function GameClient({ className, ...props }: GameClientProps) {
   );
 
   const [state, setState] = useState<S>(machineRef.current.state);
+  const [path, setPath] = useState<'a' | 'b' | null>(null);
   const messages: Record<S, string> = {
     intro: "Press 'Start game' to begin 🎮",
     playing: 'Game in progress…',
@@ -42,6 +44,9 @@ export function GameClient({ className, ...props }: GameClientProps) {
 
   const handle = (event: E) => {
     setState(machineRef.current.send(event));
+    if (event === 'reset' || event === 'start') {
+      setPath(null);
+    }
   };
 
   return (
@@ -50,7 +55,11 @@ export function GameClient({ className, ...props }: GameClientProps) {
       className={cn('flex flex-col items-center gap-4 py-8', className)}
       {...props}
     >
-      <p aria-live="polite" aria-atomic="true">{messages[state]}</p>
+      <p aria-live="polite" aria-atomic="true">
+        {state === 'playing' && path
+          ? `Path ${path.toUpperCase()} selected`
+          : messages[state]}
+      </p>
       <div>
         {state === 'intro' && (
           <Button
@@ -61,12 +70,28 @@ export function GameClient({ className, ...props }: GameClientProps) {
           />
         )}
         {state === 'playing' && (
-          <Button
-            ref={buttonRef}
-            autoFocus
-            label="Finish game"
-            onClick={() => handle('finish')}
-          />
+          <div className="flex flex-col items-center gap-2">
+            <div className="flex gap-2">
+              <ChoiceButton
+                label="Path A"
+                selected={path === 'a'}
+                onSelect={() => setPath('a')}
+                aria-label="Choose path A"
+              />
+              <ChoiceButton
+                label="Path B"
+                selected={path === 'b'}
+                onSelect={() => setPath('b')}
+                aria-label="Choose path B"
+              />
+            </div>
+            <Button
+              ref={buttonRef}
+              autoFocus
+              label="Finish game"
+              onClick={() => handle('finish')}
+            />
+          </div>
         )}
         {state === 'completed' && (
           <Button

--- a/apps/web/src/components/__tests__/GameClient.test.tsx
+++ b/apps/web/src/components/__tests__/GameClient.test.tsx
@@ -44,4 +44,16 @@ describe('GameClient', () => {
     const reset = getByRole('button', { name: /reset game/i });
     expect(reset).toHaveFocus();
   });
+
+  it('allows path selection', () => {
+    const { getByRole, getByLabelText } = render(<GameClient />);
+    fireEvent.click(getByRole('button', { name: /start game/i }));
+
+    const pathA = getByLabelText('Choose path A');
+    const pathB = getByLabelText('Choose path B');
+    expect(pathA).toHaveAttribute('aria-pressed', 'false');
+    fireEvent.click(pathA);
+    expect(pathA).toHaveAttribute('aria-pressed', 'true');
+    expect(pathB).toHaveAttribute('aria-pressed', 'false');
+  });
 });

--- a/packages/ui/src/__tests__/ChoiceButton.test.tsx
+++ b/packages/ui/src/__tests__/ChoiceButton.test.tsx
@@ -1,0 +1,17 @@
+import { fireEvent, render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { ChoiceButton } from '../components/ChoiceButton';
+
+describe('ChoiceButton', () => {
+  it('calls onSelect when clicked', () => {
+    const onSelect = vi.fn();
+    const { getByRole } = render(
+      <ChoiceButton label="Pick" onSelect={onSelect} />,
+    );
+    const button = getByRole('button', { name: /pick/i });
+    fireEvent.click(button);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/components/ChoiceButton.tsx
+++ b/packages/ui/src/components/ChoiceButton.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { cn } from '@utils/cn';
+import { Button } from './Button';
 
 /**
  * Button for selecting a choice.
@@ -38,16 +39,14 @@ export const ChoiceButton = React.forwardRef<HTMLButtonElement, ChoiceButtonProp
     };
 
     return (
-      <button
+      <Button
         {...props}
         ref={ref}
-        type="button"
+        label={label}
         aria-pressed={selected}
         className={classes}
         onClick={handleClick}
-      >
-        {label}
-      </button>
+      />
     );
   },
 );

--- a/packages/ui/src/components/ChoiceButton.tsx
+++ b/packages/ui/src/components/ChoiceButton.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import React from 'react';
+import { cn } from '@utils/cn';
+
+/**
+ * Button for selecting a choice.
+ *
+ * Adds `aria-pressed` to show selected state.
+ */
+export type ChoiceButtonProps = {
+  /** Button label */
+  label: string;
+  /** True when this option is selected */
+  selected?: boolean;
+  /** Called after selection */
+  onSelect?: () => void;
+} & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children' | 'onClick'>;
+
+export const ChoiceButton = React.forwardRef<HTMLButtonElement, ChoiceButtonProps>(
+  function ChoiceButton(
+    { label, className, selected = false, onSelect, onClick, ...props },
+    ref,
+  ) {
+    const classes = cn(
+      'rounded border px-4 py-2',
+      selected
+        ? 'bg-foreground text-background'
+        : 'bg-background text-foreground',
+      className,
+    );
+
+    const handleClick = (
+      event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    ) => {
+      onSelect?.();
+      onClick?.(event);
+    };
+
+    return (
+      <button
+        {...props}
+        ref={ref}
+        type="button"
+        aria-pressed={selected}
+        className={classes}
+        onClick={handleClick}
+      >
+        {label}
+      </button>
+    );
+  },
+);

--- a/packages/ui/src/components/ChoiceButton.tsx
+++ b/packages/ui/src/components/ChoiceButton.tsx
@@ -15,7 +15,7 @@ export type ChoiceButtonProps = {
   selected?: boolean;
   /** Called after selection */
   onSelect?: () => void;
-} & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children' | 'onClick'>;
+} & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children'>;
 
 export const ChoiceButton = React.forwardRef<HTMLButtonElement, ChoiceButtonProps>(
   function ChoiceButton(

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,2 +1,3 @@
 export * from './components/Button';
+export * from './components/ChoiceButton';
 export * from './hooks/useStoryClient';


### PR DESCRIPTION
## Summary
- add `ChoiceButton` interactive component
- expose it from UI package
- document in Storybook for the web app
- test user selection behaviour

Closes #1

------
https://chatgpt.com/codex/tasks/task_e_688cbdfc8edc8326b2daa133d5af5477

## Summary by Sourcery

Add a new ChoiceButton component to the UI library with selection support, expose it via the UI package, document it in Storybook, and add tests for selection behavior

New Features:
- Introduce ChoiceButton component with selected state and onSelect handler
- Export ChoiceButton from the UI package

Documentation:
- Add Storybook story for ChoiceButton in the web app

Tests:
- Add unit tests for ChoiceButton selection behavior and aria-pressed attribute

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new ChoiceButton component for selectable actions.
  * Added path selection functionality to the game interface, allowing users to choose between two options during gameplay.
  * Enhanced accessibility with ARIA attributes for selection buttons.

* **Tests**
  * Added tests for the ChoiceButton component to verify selection behaviour.
  * Expanded game client tests to cover path selection interactions.

* **Documentation**
  * Added Storybook stories for the new ChoiceButton component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->