### PR TITLE
feat(ui): add StatusSidebar component

### DIFF
--- a/apps/web/src/components/StatusSidebar.stories.tsx
+++ b/apps/web/src/components/StatusSidebar.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { StatusSidebar } from '@ui/components/StatusSidebar';
+
+const meta: Meta<React.ComponentProps<typeof StatusSidebar>> = {
+  title: 'Components/StatusSidebar',
+  component: StatusSidebar,
+  args: {
+    status: 'Exploring',
+    clues: ['Mysterious letter', 'Broken key'],
+    'aria-label': 'Game status sidebar',
+  },
+};
+export default meta;
+export type Story = StoryObj<typeof StatusSidebar>;
+
+export const Default: Story = {};

--- a/packages/ui/src/__tests__/StatusSidebar.test.tsx
+++ b/packages/ui/src/__tests__/StatusSidebar.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { StatusSidebar } from '../components/StatusSidebar';
+
+describe('StatusSidebar', () => {
+  it('renders status and clues list', () => {
+    const { getByText } = render(
+      <StatusSidebar status="Investigating" clues={["Found note"]} />,
+    );
+    expect(getByText('Investigating')).toBeInTheDocument();
+    expect(getByText('Found note')).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/StatusSidebar.tsx
+++ b/packages/ui/src/components/StatusSidebar.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import React from 'react';
+import { cn } from '@utils/cn';
+
+/**
+ * Sidebar panel showing the player's status and any discovered clues.
+ */
+export interface StatusSidebarProps extends React.HTMLAttributes<HTMLElement> {
+  /** Current game status string. */
+  status: string;
+  /** List of clue texts to display. */
+  clues: string[];
+}
+
+export function StatusSidebar({
+  status,
+  clues,
+  className,
+  ...props
+}: StatusSidebarProps) {
+  return (
+    <aside
+      {...props}
+      className={cn(
+        'w-60 space-y-4 border-l border-gray-200 bg-gray-50 p-4 dark:border-gray-800 dark:bg-gray-900',
+        className,
+      )}
+    >
+      <div>
+        <h2 className="text-lg font-semibold">Status</h2>
+        <p aria-live="polite" aria-atomic="true">
+          {status}
+        </p>
+      </div>
+      <div>
+        <h2 className="text-lg font-semibold">Clues</h2>
+        {clues.length > 0 ? (
+          <ul className="list-disc pl-4">
+            {clues.map((clue) => (
+              <li key={clue}>{clue}</li>
+            ))}
+          </ul>
+        ) : (
+          <p>No clues yet 🕵️</p>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,3 +1,4 @@
 export * from './components/Button';
 export * from './components/ChoiceButton';
+export * from './components/StatusSidebar';
 export * from './hooks/useStoryClient';


### PR DESCRIPTION
## Summary
- create StatusSidebar component to show game status and clues
- add unit test and storybook story

## Testing
- `yarn lint:fix`
- `yarn test`
- `yarn web:ci`

Closes #123

------
https://chatgpt.com/codex/tasks/task_e_688cc910de6c8326a4aeae2f2c045131

## Summary by Sourcery

Add a new StatusSidebar component to display game status and discovered clues in the UI library and include its export, unit tests, and Storybook story.

New Features:
- Introduce StatusSidebar component with status and clues props
- Export StatusSidebar from the UI package index

Documentation:
- Add Storybook story for the StatusSidebar component

Tests:
- Add unit tests for the StatusSidebar component