### PR TITLE
feat(utils): expose story variables

### DIFF
--- a/packages/utils/src/__tests__/story-runner.test.ts
+++ b/packages/utils/src/__tests__/story-runner.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createStoryRunner } from '../story-runner';
+import { createStoryRunner, type StoryYield } from '../story-runner';
 
 describe('createStoryRunner', () => {
   it('steps through a generator story', () => {
@@ -9,7 +9,7 @@ describe('createStoryRunner', () => {
       yield `end:${choice}`;
     }
 
-    const runner = createStoryRunner(story);
+    const runner = createStoryRunner<string, string, { intro?: boolean; asked?: boolean; name?: string }>(story);
 
     expect(runner.step().value).toBe('intro');
     expect(runner.step().value).toBe('choose');
@@ -26,5 +26,35 @@ describe('createStoryRunner', () => {
     runner.step();
     runner.reset();
     expect(runner.step().value).toBe(1);
+  });
+
+  it('tracks variables from yield output', () => {
+    function* story(): Generator<
+      StoryYield<string, { intro?: boolean; asked?: boolean; name?: string }>,
+      void,
+      string
+    > {
+      yield { value: 'intro', vars: { intro: true } };
+      const name: string = yield { value: 'ask', vars: { asked: true } };
+      yield { value: `end:${name}`, vars: { name } };
+    }
+
+    const runner = createStoryRunner<
+      string,
+      string,
+      { intro?: boolean; asked?: boolean; name?: string }
+    >(story);
+
+    runner.step();
+    expect(runner.variables).toEqual({ intro: true });
+
+    runner.step();
+    expect(runner.variables).toEqual({ intro: true, asked: true });
+
+    runner.step('sam');
+    expect(runner.variables).toEqual({ intro: true, asked: true, name: 'sam' });
+
+    runner.reset();
+    expect(runner.variables).toEqual({});
   });
 });

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -3,3 +3,4 @@ export * from './state-machine';
 export * from './supabase';
 export * from './database.types';
 export * from './story-runner';
+export type { StoryYield } from './story-runner';


### PR DESCRIPTION
## Summary
- extend story-runner to track variables via `StoryYield` shape
- export new type from utils package
- test variable handling and reset behaviour

Closes #50

------
https://chatgpt.com/codex/tasks/task_e_688cccfccaa4832688a6695275a9498a

## Summary by Sourcery

Extend the story-runner to support tracking arbitrary variables through a new yield shape, expose those variables in the runner API, export the helper type, and add tests to validate the handling and reset of variable state.

New Features:
- Expose story variables via a new `variables` property on the StoryRunner interface
- Introduce a `StoryYield` type that allows yields to include variable updates
- Export the `StoryYield` type from the utils package

Enhancements:
- Extend createStoryRunner to accumulate and reset variable state alongside story output

Tests:
- Add tests to verify variable tracking across yields and reset behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Story runners now track and expose incremental variable states alongside story output, allowing users to access merged variables during iteration.
* **Bug Fixes**
  * Resetting a story runner now also clears tracked variables.
* **Documentation**
  * Type exports have been updated to improve type safety and clarity for consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->