### PR TITLE
Refactor game client

### DIFF
--- a/apps/web/src/lib/__tests__/useGameMachine.test.tsx
+++ b/apps/web/src/lib/__tests__/useGameMachine.test.tsx
@@ -1,0 +1,34 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useGameMachine } from '../useGameMachine';
+
+describe('useGameMachine', () => {
+  it('handles state transitions and path selection', () => {
+    const { result } = renderHook(() => useGameMachine());
+
+    expect(result.current.state).toBe('intro');
+    expect(result.current.path).toBeNull();
+
+    act(() => {
+      result.current.start();
+    });
+    expect(result.current.state).toBe('playing');
+    expect(result.current.path).toBeNull();
+
+    act(() => {
+      result.current.choosePath('a');
+    });
+    expect(result.current.path).toBe('a');
+
+    act(() => {
+      result.current.finish();
+    });
+    expect(result.current.state).toBe('completed');
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.state).toBe('intro');
+    expect(result.current.path).toBeNull();
+  });
+});

--- a/apps/web/src/lib/useGameMachine.ts
+++ b/apps/web/src/lib/useGameMachine.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { createStateMachine } from '@utils/state-machine';
+
+/**
+ * Manage the game state machine used by {@link GameClient}.
+ */
+export function useGameMachine() {
+  type S = 'intro' | 'playing' | 'completed';
+  type E = 'start' | 'finish' | 'reset';
+
+  const machineRef = useRef(
+    createStateMachine<S, E>({
+      initial: 'intro',
+      transitions: {
+        intro: { start: 'playing' },
+        playing: { finish: 'completed' },
+        completed: { reset: 'intro' },
+      },
+    }),
+  );
+
+  const [state, setState] = useState<S>(machineRef.current.state);
+  const [path, setPath] = useState<'a' | 'b' | null>(null);
+
+  const send = (event: E) => setState(machineRef.current.send(event));
+
+  const start = () => {
+    send('start');
+    setPath(null);
+  };
+
+  const finish = () => send('finish');
+
+  const reset = () => {
+    send('reset');
+    setPath(null);
+  };
+
+  const choosePath = (p: 'a' | 'b') => setPath(p);
+
+  return { state, path, start, finish, reset, choosePath };
+}


### PR DESCRIPTION
## Summary
- extract `useGameMachine` hook for game state
- update `GameClient` to use the new hook
- test `useGameMachine`

Closes #1

------
https://chatgpt.com/codex/tasks/task_e_688cf720b2048326a3c32b2e2acc4048

## Summary by Sourcery

Extract the game state logic into a reusable useGameMachine hook, refactor GameClient to use the hook, and add tests for the new hook

New Features:
- Introduce useGameMachine hook to manage game state

Enhancements:
- Refactor GameClient to consume useGameMachine instead of inline state machine

Tests:
- Add unit tests for useGameMachine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the game client component by delegating state management and control logic to a new custom hook.
* **New Features**
  * Introduced a custom hook for managing game state and actions.
* **Tests**
  * Added a new test suite to verify game state transitions and path selection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->