### PR TITLE
feat(web): wire game provider into home page

### DIFF
--- a/apps/web/src/app/__tests__/HomePage.test.tsx
+++ b/apps/web/src/app/__tests__/HomePage.test.tsx
@@ -5,11 +5,15 @@ import { describe, expect, it } from 'vitest';
 import HomePage from '../page';
 
 describe('HomePage', () => {
-  it('renders the game client', () => {
-    const { getByLabelText, getByRole } = render(<HomePage />);
+  it('renders game client with sidebar', () => {
+    const { getByLabelText, getByRole, getByText } = render(<HomePage />);
     const main = getByRole('main');
     const client = getByLabelText(/demo game client/i);
+    const sidebar = getByLabelText(/game status sidebar/i);
     expect(client).toBeInTheDocument();
     expect(main).toContainElement(client);
+    expect(sidebar).toBeInTheDocument();
+    expect(getByText(/idle/i)).toBeInTheDocument();
+    expect(getByText(/no clues yet/i)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,16 +1,25 @@
 import Image from 'next/image';
 import React from 'react';
+import { GameProvider } from '@ui/hooks/useGameContext';
 import { GameClient } from '../components/GameClient';
+import { GameSidebar } from '../components/GameSidebar';
 import { HomeHero } from '../components/HomeHero';
 
 /**
  * Home page with the hero section and game client.
+ *
+ * Wraps the game area in {@link GameProvider} to expose global game state.
  */
 export default function HomePage() {
   return (
     <main id="story" role="main" className="mx-auto max-w-3xl p-4" tabIndex={-1}>
       <HomeHero />
-      <GameClient className="mt-4" aria-label="Demo game client" />
+      <GameProvider>
+        <div className="mt-4 flex gap-4">
+          <GameClient className="flex-1" aria-label="Demo game client" />
+          <GameSidebar aria-label="Game status sidebar" />
+        </div>
+      </GameProvider>
       <div className="mt-10 flex justify-center">
         <Image
           className="dark:invert"

--- a/apps/web/src/components/GameClient.tsx
+++ b/apps/web/src/components/GameClient.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useRef } from 'react';
 import { Button } from '@ui/components/Button';
 import { ChoiceButton } from '@ui/components/ChoiceButton';
+import { useGame } from '@ui/hooks/useGameContext';
 import { cn } from '@utils/cn';
 import { useGameMachine } from '@/lib/useGameMachine';
 
@@ -16,7 +17,15 @@ export type GameClientProps = React.HTMLAttributes<HTMLElement>;
 
 export function GameClient({ className, ...props }: GameClientProps) {
   const buttonRef = useRef<HTMLButtonElement>(null);
-  const { state, path, start, finish, reset, choosePath } = useGameMachine();
+  const {
+    state,
+    path,
+    start,
+    finish,
+    reset: machineReset,
+    choosePath: machineChoosePath,
+  } = useGameMachine();
+  const { setStatus, addClue, reset } = useGame();
   const messages: Record<typeof state, string> = {
     intro: "Press 'Start game' to begin 🎮",
     playing: 'Game in progress…',
@@ -26,6 +35,28 @@ export function GameClient({ className, ...props }: GameClientProps) {
   useEffect(() => {
     buttonRef.current?.focus();
   }, [state]);
+
+  useEffect(() => {
+    if (state === 'intro') {
+      reset();
+      return;
+    }
+    if (state === 'playing') {
+      setStatus('Game in progress…');
+      return;
+    }
+    setStatus('Game over 🎉');
+  }, [state, reset, setStatus]);
+
+  const resetGame = () => {
+    machineReset();
+    reset();
+  };
+
+  const choosePath = (p: 'a' | 'b') => {
+    addClue(`Path ${p.toUpperCase()} selected`);
+    machineChoosePath(p);
+  };
 
   return (
     <section
@@ -66,17 +97,17 @@ export function GameClient({ className, ...props }: GameClientProps) {
             <Button
               ref={buttonRef}
               autoFocus
-              label="Finish game"
-              onClick={finish}
-            />
-          </div>
-        )}
+            label="Finish game"
+            onClick={finish}
+          />
+        </div>
+      )}
         {state === 'completed' && (
           <Button
             ref={buttonRef}
             autoFocus
             label="Reset game"
-            onClick={reset}
+            onClick={resetGame}
           />
         )}
       </div>

--- a/apps/web/src/components/GameSidebar.stories.tsx
+++ b/apps/web/src/components/GameSidebar.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { GameProvider } from '@ui/hooks/useGameContext';
+import { GameSidebar } from './GameSidebar';
+
+const meta: Meta<React.ComponentProps<typeof GameSidebar>> = {
+  title: 'Components/GameSidebar',
+  component: GameSidebar,
+  decorators: [
+    (Story: React.ComponentType) => (
+      <GameProvider>
+        <Story />
+      </GameProvider>
+    ),
+  ],
+  args: {
+    'aria-label': 'Game status sidebar',
+  },
+};
+
+export default meta;
+export type Story = StoryObj<typeof GameSidebar>;
+
+export const Default: Story = {};

--- a/apps/web/src/components/GameSidebar.tsx
+++ b/apps/web/src/components/GameSidebar.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import React from 'react';
+import { StatusSidebar, type StatusSidebarProps } from '@ui/components/StatusSidebar';
+import { useGame } from '@ui/hooks/useGameContext';
+
+/** Props for {@link GameSidebar}. */
+export type GameSidebarProps = Omit<StatusSidebarProps, 'status' | 'clues'>;
+
+/**
+ * Sidebar that reads game state from {@link GameProvider}.
+ */
+export function GameSidebar(props: GameSidebarProps) {
+  const { status, clues } = useGame();
+  return <StatusSidebar status={status} clues={clues} {...props} />;
+}

--- a/apps/web/src/components/__tests__/GameClient.test.tsx
+++ b/apps/web/src/components/__tests__/GameClient.test.tsx
@@ -2,11 +2,17 @@ import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
 import { describe, expect, it } from 'vitest';
+import { GameProvider } from '@ui/hooks/useGameContext';
 import { GameClient } from '../GameClient';
+import { GameSidebar } from '../GameSidebar';
 
 describe('GameClient', () => {
   it('progresses through the game states', () => {
-    const { getByRole, getByText } = render(<GameClient />);
+    const { getByRole, getByText } = render(
+      <GameProvider>
+        <GameClient />
+      </GameProvider>,
+    );
     const region = getByRole('region');
     expect(region).toBeInTheDocument();
     expect(region.firstChild).toHaveAttribute('aria-live', 'polite');
@@ -31,7 +37,11 @@ describe('GameClient', () => {
   });
 
   it('focuses new button when state changes', () => {
-    const { getByRole } = render(<GameClient />);
+    const { getByRole } = render(
+      <GameProvider>
+        <GameClient />
+      </GameProvider>,
+    );
 
     const start = getByRole('button', { name: /start game/i });
     expect(start).toHaveFocus();
@@ -46,7 +56,11 @@ describe('GameClient', () => {
   });
 
   it('allows path selection', () => {
-    const { getByRole, getByLabelText } = render(<GameClient />);
+    const { getByRole, getByLabelText } = render(
+      <GameProvider>
+        <GameClient />
+      </GameProvider>,
+    );
     fireEvent.click(getByRole('button', { name: /start game/i }));
 
     const pathA = getByLabelText('Choose path A');
@@ -55,5 +69,23 @@ describe('GameClient', () => {
     fireEvent.click(pathA);
     expect(pathA).toHaveAttribute('aria-pressed', 'true');
     expect(pathB).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('updates status and clues in context', () => {
+    const { getByRole, getByLabelText, getByText, getAllByText } = render(
+      <GameProvider>
+        <div>
+          <GameClient />
+          <GameSidebar />
+        </div>
+      </GameProvider>,
+    );
+
+    fireEvent.click(getByRole('button', { name: /start game/i }));
+    fireEvent.click(getByLabelText('Choose path A'));
+    fireEvent.click(getByRole('button', { name: /finish game/i }));
+
+    expect(getAllByText(/game over/i)).toHaveLength(2);
+    expect(getByText(/path a selected/i)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/__tests__/GameSidebar.test.tsx
+++ b/apps/web/src/components/__tests__/GameSidebar.test.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { GameProvider } from '@ui/hooks/useGameContext';
+import { GameSidebar } from '../GameSidebar';
+
+describe('GameSidebar', () => {
+  it('shows default status and no clues', () => {
+    const { getByText } = render(
+      <GameProvider>
+        <GameSidebar />
+      </GameProvider>,
+    );
+    expect(getByText(/idle/i)).toBeInTheDocument();
+    expect(getByText(/no clues yet/i)).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/hooks/useGameContext.tsx
+++ b/packages/ui/src/hooks/useGameContext.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
 
 /**


### PR DESCRIPTION
## Summary
- wrap game client with provider and sidebar
- sync game status and clues through context
- add tests and storybook entry

## Testing
- `yarn lint:fix`
- `yarn test`
- `yarn web:ci`

Closes #123

------
https://chatgpt.com/codex/tasks/task_e_688f1cb64ee08326bbae56616be200a7

## Summary by Sourcery

Integrate the game context provider into the home page, enhance the GameClient to synchronize with global game state and clues, and introduce a GameSidebar component with corresponding tests and a Storybook story.

New Features:
- Add GameSidebar component to display game status and clues
- Wrap GameClient and GameSidebar in GameProvider on the home page

Enhancements:
- Sync game machine state and clue updates through GameContext in GameClient
- Refactor GameClient reset and path selection to update context status and clues

Documentation:
- Add Storybook entry for GameSidebar

Tests:
- Update GameClient tests to include GameProvider and verify context-driven status and clue updates
- Add tests for GameSidebar component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a sidebar displaying real-time game status and clues alongside the game client.
  * Added a new GameSidebar component that automatically reflects the current game state.
  * The main game page now displays both the game client and sidebar in a unified layout.

* **Bug Fixes**
  * Improved synchronisation between game state and UI, ensuring status and clues update consistently.

* **Tests**
  * Added and updated tests to verify correct rendering and state propagation in the game client and sidebar components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->