### PR TITLE
feat: show actual status in panel

### DIFF
--- a/apps/web/src/components/GameSidebar.stories.tsx
+++ b/apps/web/src/components/GameSidebar.stories.tsx
@@ -13,9 +13,9 @@ const meta: Meta<React.ComponentProps<typeof GameSidebar>> = {
       </GameProvider>
     ),
   ],
-  args: {
-    'aria-label': 'Game status sidebar',
-  },
+    args: {
+      'aria-label': 'Game status sidebar',
+    },
 };
 
 export default meta;

--- a/apps/web/src/components/GameSidebar.tsx
+++ b/apps/web/src/components/GameSidebar.tsx
@@ -1,16 +1,14 @@
 'use client';
 
 import React from 'react';
-import { StatusSidebar, type StatusSidebarProps } from '@ui/components/StatusSidebar';
-import { useGame } from '@ui/hooks/useGameContext';
+import { StatusSidebar } from '@ui/components/StatusSidebar';
 
 /** Props for {@link GameSidebar}. */
-export type GameSidebarProps = Omit<StatusSidebarProps, 'status' | 'clues'>;
+export type GameSidebarProps = React.ComponentProps<typeof StatusSidebar>;
 
 /**
- * Sidebar that reads game state from {@link GameProvider}.
+ * Sidebar that proxies {@link StatusSidebar}.
  */
 export function GameSidebar(props: GameSidebarProps) {
-  const { status, clues } = useGame();
-  return <StatusSidebar status={status} clues={clues} {...props} />;
+  return <StatusSidebar {...props} />;
 }

--- a/apps/web/src/components/StatusSidebar.stories.tsx
+++ b/apps/web/src/components/StatusSidebar.stories.tsx
@@ -1,17 +1,30 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import React from 'react';
+import React, { useEffect } from 'react';
+import { GameProvider, useGame } from '@ui/hooks/useGameContext';
 import { StatusSidebar } from '@ui/components/StatusSidebar';
 
 const meta: Meta<React.ComponentProps<typeof StatusSidebar>> = {
   title: 'Components/StatusSidebar',
   component: StatusSidebar,
-  args: {
-    status: 'Exploring',
-    clues: ['Mysterious letter', 'Broken key'],
-    'aria-label': 'Game status sidebar',
-  },
+  decorators: [
+    (Story: React.ComponentType) => (
+      <GameProvider>
+        <Story />
+      </GameProvider>
+    ),
+  ],
 };
 export default meta;
 export type Story = StoryObj<typeof StatusSidebar>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  render: function Render() {
+      const { setStatus, addClue } = useGame();
+      useEffect(() => {
+        setStatus('Exploring');
+        addClue('Mysterious letter');
+        addClue('Broken key');
+      }, [setStatus, addClue]);
+      return <StatusSidebar aria-label='Game status sidebar' />;
+    },
+  };

--- a/packages/ui/src/__tests__/StatusSidebar.test.tsx
+++ b/packages/ui/src/__tests__/StatusSidebar.test.tsx
@@ -1,15 +1,27 @@
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { describe, expect, it } from 'vitest';
+import { GameProvider, useGame } from '../hooks/useGameContext';
 import { StatusSidebar } from '../components/StatusSidebar';
 
 describe('StatusSidebar', () => {
   it('renders status and clues list', () => {
-    const { getByText } = render(
-      <StatusSidebar status="Investigating" clues={["Found note"]} />,
-    );
-    expect(getByText('Investigating')).toBeInTheDocument();
-    expect(getByText('Found note')).toBeInTheDocument();
+    function Setup() {
+        const { setStatus, addClue } = useGame();
+        useEffect(() => {
+          setStatus('Investigating');
+          addClue('Found note');
+        }, [setStatus, addClue]);
+        return <StatusSidebar />;
+      }
+
+      const { getByText } = render(
+        <GameProvider>
+          <Setup />
+        </GameProvider>,
+      );
+      expect(getByText('Investigating')).toBeInTheDocument();
+      expect(getByText('Found note')).toBeInTheDocument();
+    });
   });
-});

--- a/packages/ui/src/components/StatusSidebar.tsx
+++ b/packages/ui/src/components/StatusSidebar.tsx
@@ -1,24 +1,16 @@
-'use client'
+'use client';
 
 import React from 'react';
 import { cn } from '@utils/cn';
+import { useGame } from '../hooks/useGameContext';
 
 /**
- * Sidebar panel showing the player's status and any discovered clues.
+ * Sidebar panel showing the player's current status and discovered clues.
  */
-export interface StatusSidebarProps extends React.HTMLAttributes<HTMLElement> {
-  /** Current game status string. */
-  status: string;
-  /** List of clue texts to display. */
-  clues: string[];
-}
+export type StatusSidebarProps = React.HTMLAttributes<HTMLElement>;
 
-export function StatusSidebar({
-  status,
-  clues,
-  className,
-  ...props
-}: StatusSidebarProps) {
+export function StatusSidebar({ className, ...props }: StatusSidebarProps) {
+  const { status, clues } = useGame();
   return (
     <aside
       {...props}


### PR DESCRIPTION
## Summary
- use game context directly in status panel
- streamline game sidebar as a proxy
- test status panel reads context data

## Testing
- `yarn lint:fix`
- `yarn test`
- `yarn web:ci`
- `git secrets --scan`

Closes #123

------
https://chatgpt.com/codex/tasks/task_e_688f2b55ca708326950283410b02703d