### PR TITLE
feat: add rate limit helper action

### DIFF
--- a/apps/web/src/app/__tests__/rateLimitActions.test.ts
+++ b/apps/web/src/app/__tests__/rateLimitActions.test.ts
@@ -29,4 +29,16 @@ describe('rate limit action', () => {
     expect(allowedAgain).toBe(true);
     vi.useRealTimers();
   });
+
+  it('clamps window to one hour', async () => {
+    vi.useFakeTimers();
+    const HOUR = 3_600_000;
+    const key = 'clamp';
+    const options = { windowMs: HOUR * 2, limit: 1 } as const;
+    expect(await rateLimit(key, options)).toBe(true);
+    expect(await rateLimit(key, options)).toBe(false);
+    vi.advanceTimersByTime(HOUR);
+    expect(await rateLimit(key, options)).toBe(true);
+    vi.useRealTimers();
+  });
 });

--- a/apps/web/src/app/__tests__/rateLimitActions.test.ts
+++ b/apps/web/src/app/__tests__/rateLimitActions.test.ts
@@ -1,0 +1,19 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { rateLimit } from '../_actions/rate-limit';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('rate limit action', () => {
+  it('allows up to limit then blocks', async () => {
+    const key = 'user';
+    for (let i = 0; i < 5; i++) {
+      const allowed = await rateLimit(key);
+      expect(allowed).toBe(true);
+    }
+    const blocked = await rateLimit(key);
+    expect(blocked).toBe(false);
+  });
+});

--- a/apps/web/src/app/__tests__/rateLimitActions.test.ts
+++ b/apps/web/src/app/__tests__/rateLimitActions.test.ts
@@ -16,4 +16,17 @@ describe('rate limit action', () => {
     const blocked = await rateLimit(key);
     expect(blocked).toBe(false);
   });
+
+  it('resets after the window', async () => {
+    vi.useFakeTimers();
+    const key = 'reset';
+    const allowed = await rateLimit(key, { windowMs: 100, limit: 1 });
+    expect(allowed).toBe(true);
+    const blocked = await rateLimit(key, { windowMs: 100, limit: 1 });
+    expect(blocked).toBe(false);
+    vi.advanceTimersByTime(100);
+    const allowedAgain = await rateLimit(key, { windowMs: 100, limit: 1 });
+    expect(allowedAgain).toBe(true);
+    vi.useRealTimers();
+  });
 });

--- a/apps/web/src/app/_actions/rate-limit.ts
+++ b/apps/web/src/app/_actions/rate-limit.ts
@@ -1,0 +1,30 @@
+'use server';
+
+interface RateLimitOptions {
+  /** Time window in milliseconds. */
+  windowMs?: number;
+  /** Maximum allowed requests per window. */
+  limit?: number;
+}
+
+/**
+ * Enforce a simple in-memory rate limit.
+ *
+ * @param key - Identifier such as user id or IP.
+ * @param options - Configuration for limit and window.
+ * @returns Whether the request is allowed.
+ */
+export async function rateLimit(
+  key: string,
+  { windowMs = 60_000, limit = 5 }: RateLimitOptions = {},
+): Promise<boolean> {
+  const now = Date.now();
+  const hits = store.get(key) ?? [];
+  const recent = hits.filter((t) => now - t < windowMs);
+  if (recent.length >= limit) return false;
+  recent.push(now);
+  store.set(key, recent);
+  return true;
+}
+
+const store = new Map<string, number[]>();

--- a/apps/web/src/app/_actions/rate-limit.ts
+++ b/apps/web/src/app/_actions/rate-limit.ts
@@ -7,6 +7,11 @@ interface RateLimitOptions {
   limit?: number;
 }
 
+interface StoreEntry {
+  timestamps: number[];
+  timeout?: ReturnType<typeof setTimeout>;
+}
+
 /**
  * Enforce a simple in-memory rate limit.
  *
@@ -19,12 +24,18 @@ export async function rateLimit(
   { windowMs = 60_000, limit = 5 }: RateLimitOptions = {},
 ): Promise<boolean> {
   const now = Date.now();
-  const hits = store.get(key) ?? [];
-  const recent = hits.filter((t) => now - t < windowMs);
+  const entry = store.get(key) ?? { timestamps: [] };
+  const recent = entry.timestamps.filter((t) => now - t < windowMs);
   if (recent.length >= limit) return false;
   recent.push(now);
-  store.set(key, recent);
+  entry.timestamps = recent;
+  if (entry.timeout) clearTimeout(entry.timeout);
+  entry.timeout = setTimeout(() => {
+    store.delete(key);
+  }, windowMs);
+  entry.timeout.unref?.();
+  store.set(key, entry);
   return true;
 }
 
-const store = new Map<string, number[]>();
+const store = new Map<string, StoreEntry>();


### PR DESCRIPTION
## Summary
- add in-memory rate limit server action
- test rate limit behaviour

## Testing
- `yarn lint:fix`
- `yarn web:ci`
- `git secrets --scan`

Closes #123

------
https://chatgpt.com/codex/tasks/task_e_688fc0e4e52c8326b08b447641bdf938

## Summary by Sourcery

Introduce an in-memory rate limit helper action to control request frequency based on a time window and limit, and add tests to validate its behavior.

New Features:
- Add rateLimit server action for in-memory request throttling with configurable window and limit

Tests:
- Add unit tests to verify rate limit enforcement behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a rate limiting mechanism to restrict the number of allowed actions within a specified time window.  
* **Tests**
  * Added automated tests to verify correct rate limiting behaviour and reset functionality after the time window expires.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->