### PR TITLE
feat: add flavour generation action

### DIFF
--- a/apps/web/src/app/__tests__/flavourActions.test.ts
+++ b/apps/web/src/app/__tests__/flavourActions.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../_actions/openai', () => ({ generateText: vi.fn() }));
+
+import { generateFlavour } from '../_actions/flavour';
+import { generateText } from '../_actions/openai';
+
+const mockGenerateText = vi.mocked(generateText);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('flavour server actions', () => {
+  it('creates flavour text for a topic', async () => {
+    mockGenerateText.mockResolvedValue('Moody hall');
+
+    const result = await generateFlavour('a dark hallway');
+
+    expect(generateText).toHaveBeenCalledWith(
+      'Compose a single immersive sentence about a dark hallway for a mystery game.',
+    );
+    expect(result).toBe('Moody hall');
+  });
+});

--- a/apps/web/src/app/_actions/flavour.ts
+++ b/apps/web/src/app/_actions/flavour.ts
@@ -1,0 +1,14 @@
+'use server';
+
+import { generateText } from './openai';
+
+/**
+ * Generate atmospheric flavour text for a topic.
+ *
+ * @param topic - Subject to describe.
+ * @returns Generated flavour text.
+ */
+export async function generateFlavour(topic: string): Promise<string> {
+  const prompt = `Compose a single immersive sentence about ${topic} for a mystery game.`;
+  return generateText(prompt);
+}


### PR DESCRIPTION
## Summary
- add server action to craft flavour text via OpenAI
- test flavour generation prompt

## Testing
- `yarn lint:fix`
- `yarn web:ci`

Closes #54

------
https://chatgpt.com/codex/tasks/task_e_6890629ed82483268b8cb220bccfb70e

## Summary by Sourcery

Add a new server action to generate immersive flavour text for a given topic using OpenAI and cover it with unit tests.

New Features:
- Introduce generateFlavour server action that composes atmospheric flavour text via OpenAI

Tests:
- Add unit tests for generateFlavour action, mocking the OpenAI call and verifying the prompt and result

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to generate immersive flavour text for mystery game topics.
* **Tests**
  * Introduced tests to ensure correct generation of flavour text based on provided topics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->