### PR TITLE
feat: add hint generation action

### DIFF
--- a/apps/web/src/app/__tests__/hintActions.test.ts
+++ b/apps/web/src/app/__tests__/hintActions.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../_actions/openai', () => ({ generateText: vi.fn() }));
+
+import { generateHint } from '../_actions/hint';
+import { generateText } from '../_actions/openai';
+
+const mockGenerateText = vi.mocked(generateText);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('hint server actions', () => {
+  it('creates a hint for a puzzle', async () => {
+    mockGenerateText.mockResolvedValue('Check the painting 🖼️');
+
+    const result = await generateHint('A locked door puzzle');
+
+    expect(generateText).toHaveBeenCalledWith(
+      'Offer a single subtle hint for the following puzzle without revealing the answer:\nA locked door puzzle',
+    );
+    expect(result).toBe('Check the painting 🖼️');
+  });
+});

--- a/apps/web/src/app/_actions/hint.ts
+++ b/apps/web/src/app/_actions/hint.ts
@@ -1,0 +1,15 @@
+'use server';
+
+import { generateText } from './openai';
+
+/**
+ * Generate a subtle hint for a puzzle.
+ *
+ * @param puzzle - Description of the puzzle.
+ * @returns Generated hint text.
+ */
+export async function generateHint(puzzle: string): Promise<string> {
+  const prompt =
+    `Offer a single subtle hint for the following puzzle without revealing the answer:\n${puzzle}`;
+  return generateText(prompt);
+}


### PR DESCRIPTION
## Summary
- add server action to generate subtle hints using OpenAI
- cover hint action with unit test

## Testing
- `yarn lint:fix`
- `yarn web:ci`

Closes #123

------
https://chatgpt.com/codex/tasks/task_e_689065cd18c88326beb3f0e0625c6c53

## Summary by Sourcery

Add a server action to generate subtle puzzle hints using OpenAI and cover it with unit tests

New Features:
- Add generateHint server action to produce subtle hints via OpenAI

Tests:
- Add unit tests for generateHint action with mocked OpenAI generateText

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a server-side function to generate subtle hints for puzzles without revealing answers.

* **Tests**
  * Added tests to verify the correct behaviour of the hint generation feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->