### PR TITLE
feat: add global hint button

### DIFF
--- a/apps/web/src/app/__tests__/HomePage.test.tsx
+++ b/apps/web/src/app/__tests__/HomePage.test.tsx
@@ -2,11 +2,16 @@ import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
 import { describe, expect, it } from 'vitest';
+import { GameProvider } from '@ui/hooks/useGameContext';
 import HomePage from '../page';
 
 describe('HomePage', () => {
   it('renders game client with sidebar', () => {
-    const { getByLabelText, getByRole, getByText } = render(<HomePage />);
+    const { getByLabelText, getByRole, getByText } = render(
+      <GameProvider>
+        <HomePage />
+      </GameProvider>,
+    );
     const main = getByRole('main');
     const client = getByLabelText(/demo game client/i);
     const sidebar = getByLabelText(/game status sidebar/i);

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,7 +2,10 @@ import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import React from 'react';
 
+import { GameProvider } from '@ui/hooks/useGameContext';
+
 import { Header } from '../components/Header';
+import { NeedHintButton } from '../components/NeedHintButton';
 import { SkipLink } from '../components/SkipLink';
 
 import './globals.css';
@@ -36,9 +39,12 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <React.StrictMode>
-          <SkipLink />
-          <Header />
-          {children}
+          <GameProvider>
+            <SkipLink />
+            <Header />
+            {children}
+            <NeedHintButton className="fixed bottom-4 right-4" />
+          </GameProvider>
         </React.StrictMode>
       </body>
     </html>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,25 +1,20 @@
 import Image from 'next/image';
 import React from 'react';
-import { GameProvider } from '@ui/hooks/useGameContext';
 import { GameClient } from '../components/GameClient';
 import { GameSidebar } from '../components/GameSidebar';
 import { HomeHero } from '../components/HomeHero';
 
 /**
  * Home page with the hero section and game client.
- *
- * Wraps the game area in {@link GameProvider} to expose global game state.
  */
 export default function HomePage() {
   return (
     <main id="story" role="main" className="mx-auto max-w-3xl p-4" tabIndex={-1}>
       <HomeHero />
-      <GameProvider>
-        <div className="mt-4 flex gap-4">
-          <GameClient className="flex-1" aria-label="Demo game client" />
-          <GameSidebar aria-label="Game status sidebar" />
-        </div>
-      </GameProvider>
+      <div className="mt-4 flex gap-4">
+        <GameClient className="flex-1" aria-label="Demo game client" />
+        <GameSidebar aria-label="Game status sidebar" />
+      </div>
       <div className="mt-10 flex justify-center">
         <Image
           className="dark:invert"

--- a/apps/web/src/components/NeedHintButton.tsx
+++ b/apps/web/src/components/NeedHintButton.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Button } from '@ui/components/Button';
+import { useGame } from '@ui/hooks/useGameContext';
+import { generateHint } from '../app/_actions/hint';
+
+/** Props for {@link NeedHintButton}. */
+export interface NeedHintButtonProps {
+  /** Additional classes for positioning. */
+  className?: string;
+}
+
+/**
+ * Button that fetches a hint for the current puzzle and stores it as a clue.
+ */
+export function NeedHintButton({ className }: NeedHintButtonProps) {
+  const { status, addClue } = useGame();
+  const [pending, setPending] = useState(false);
+
+  const onClick = async () => {
+    if (pending) return;
+    setPending(true);
+    try {
+      const hint = await generateHint(status);
+      addClue(hint);
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <Button
+      label={pending ? 'Fetching hint…' : 'Need a hint? 💡'}
+      className={className}
+      disabled={pending}
+      onClick={onClick}
+    />
+  );
+}

--- a/apps/web/src/components/__tests__/NeedHintButton.test.tsx
+++ b/apps/web/src/components/__tests__/NeedHintButton.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { StatusSidebar } from '@ui/components/StatusSidebar';
+import { GameProvider } from '@ui/hooks/useGameContext';
+import { NeedHintButton } from '../NeedHintButton';
+import { generateHint } from '../../app/_actions/hint';
+
+vi.mock('../../app/_actions/hint', () => ({ generateHint: vi.fn() }));
+
+const mockGenerateHint = vi.mocked(generateHint);
+
+describe('NeedHintButton', () => {
+  it('adds generated hint to clues', async () => {
+    mockGenerateHint.mockResolvedValue('Check the drawer 🗄️');
+
+    const { getByRole, findByText } = render(
+      <GameProvider>
+        <div>
+          <NeedHintButton />
+          <StatusSidebar />
+        </div>
+      </GameProvider>,
+    );
+
+    fireEvent.click(getByRole('button', { name: /need a hint/i }));
+
+    expect(await findByText('Check the drawer 🗄️')).toBeInTheDocument();
+    expect(generateHint).toHaveBeenCalledWith('Idle');
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable NeedHintButton to fetch and store puzzle hints
- provide global GameProvider and floating hint button in app layout
- cover HomePage with provider-aware test and add NeedHintButton tests

## Testing
- `yarn lint:fix`
- `yarn test`
- `yarn web:ci`

Closes #123

------
https://chatgpt.com/codex/tasks/task_e_68906a1eab74832692c062f5a29d5eb7

## Summary by Sourcery

Provide a reusable hint button component and wrap the application in a global game provider, moving state context to the root layout and adding relevant tests

New Features:
- Introduce a NeedHintButton component to fetch and store puzzle hints
- Add a global floating hint button in the app layout under GameProvider

Enhancements:
- Move GameProvider wrapper from HomePage to RootLayout for consistent global state

Tests:
- Add provider-aware tests for HomePage
- Add unit tests for NeedHintButton to verify hint fetching and state updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Need a hint" button, allowing users to request hints for the current puzzle directly from the interface.

* **Refactor**
  * Updated the application layout to consistently provide game context across all pages and components.

* **Tests**
  * Introduced tests for the "Need a hint" button to ensure correct behaviour and integration with the game context.
  * Modified HomePage tests to include the game context provider for more accurate testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->