### PR TITLE
feat: add AI cache table

### DIFF
--- a/supabase/migrations/20250730070000_create_ai_cache_table.sql
+++ b/supabase/migrations/20250730070000_create_ai_cache_table.sql
@@ -1,0 +1,15 @@
+-- Migration: Create ai_cache table
+-- Stores AI responses for reuse.
+
+create table if not exists public.ai_cache (
+  id uuid primary key default uuid_generate_v4(),
+  inserted_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  cache_key text not null,
+  value jsonb not null default '{}'::jsonb
+);
+
+create trigger ai_cache_update_timestamp
+  before update on public.ai_cache
+  for each row
+  execute procedure public.update_timestamp();

--- a/supabase/migrations/20250730070100_enable_ai_cache_rls.sql
+++ b/supabase/migrations/20250730070100_enable_ai_cache_rls.sql
@@ -1,0 +1,17 @@
+-- Migration: Enable row-level security for ai_cache table
+
+alter table if exists public.ai_cache
+  add column if not exists user_id uuid references auth.users(id);
+
+alter table public.ai_cache
+  alter column user_id set default auth.uid(),
+  alter column user_id set not null;
+
+alter table public.ai_cache
+  add constraint ai_cache_user_key_unique unique (user_id, cache_key);
+
+alter table public.ai_cache
+  enable row level security;
+
+create policy "Users can access their own cache entries" on public.ai_cache
+  for all using (auth.uid() = user_id) with check (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add ai_cache table and trigger
- enforce row level security with per-user policy

## Testing
- `yarn lint:fix`
- `yarn test`

Closes #123

------
https://chatgpt.com/codex/tasks/task_e_689077249454832681567eabaf7570a8