### PR TITLE
feat(web): add hint client hook

### DIFF
--- a/apps/web/src/components/NeedHintButton.tsx
+++ b/apps/web/src/components/NeedHintButton.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import React, { useState } from 'react';
+import React from 'react';
 import { Button } from '@ui/components/Button';
-import { useGame } from '@ui/hooks/useGameContext';
-import { generateHint } from '../app/_actions/hint';
+import { useHint } from '../hooks/useHint';
 
 /** Props for {@link NeedHintButton}. */
 export interface NeedHintButtonProps {
@@ -15,26 +14,14 @@ export interface NeedHintButtonProps {
  * Button that fetches a hint for the current puzzle and stores it as a clue.
  */
 export function NeedHintButton({ className }: NeedHintButtonProps) {
-  const { status, addClue } = useGame();
-  const [pending, setPending] = useState(false);
-
-  const onClick = async () => {
-    if (pending) return;
-    setPending(true);
-    try {
-      const hint = await generateHint(status);
-      addClue(hint);
-    } finally {
-      setPending(false);
-    }
-  };
+  const { fetchHint, pending } = useHint();
 
   return (
     <Button
       label={pending ? 'Fetching hint…' : 'Need a hint? 💡'}
       className={className}
       disabled={pending}
-      onClick={onClick}
+      onClick={fetchHint}
     />
   );
 }

--- a/apps/web/src/hooks/__tests__/useHint.test.tsx
+++ b/apps/web/src/hooks/__tests__/useHint.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { GameProvider, useGame } from '@ui/hooks/useGameContext';
+import { useHint } from '../useHint';
+import { generateHint } from '../../app/_actions/hint';
+
+vi.mock('../../app/_actions/hint', () => ({ generateHint: vi.fn() }));
+
+const mockGenerateHint = vi.mocked(generateHint);
+
+function HookConsumer() {
+  const { clues } = useGame();
+  const { fetchHint, pending } = useHint();
+  return (
+    <div>
+      <button disabled={pending} onClick={fetchHint}>
+        Get hint
+      </button>
+      {clues.map((c) => (
+        <p key={c}>{c}</p>
+      ))}
+    </div>
+  );
+}
+
+describe('useHint', () => {
+  it('adds generated hint to clues', async () => {
+    mockGenerateHint.mockResolvedValue('Look under the mat 🏠');
+
+    const { getByRole, findByText } = render(
+      <GameProvider>
+        <HookConsumer />
+      </GameProvider>,
+    );
+
+    fireEvent.click(getByRole('button', { name: /get hint/i }));
+
+    expect(await findByText('Look under the mat 🏠')).toBeInTheDocument();
+    expect(generateHint).toHaveBeenCalledWith('Idle');
+  });
+});
+

--- a/apps/web/src/hooks/useHint.ts
+++ b/apps/web/src/hooks/useHint.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useGame } from '@ui/hooks/useGameContext';
+import { generateHint } from '../app/_actions/hint';
+
+/**
+ * Hook for generating and storing puzzle hints.
+ *
+ * Provides a `fetchHint` function that retrieves a hint for the current puzzle
+ * and adds it to the game clues. It exposes a `pending` flag while the request
+ * is in flight.
+ *
+ * @returns Hint helpers.
+ */
+export function useHint() {
+  const { status, addClue } = useGame();
+  const [pending, setPending] = useState(false);
+
+  const fetchHint = useCallback(async () => {
+    if (pending) return;
+    setPending(true);
+    try {
+      const hint = await generateHint(status);
+      addClue(hint);
+    } finally {
+      setPending(false);
+    }
+  }, [pending, status, addClue]);
+
+  return { fetchHint, pending };
+}
+


### PR DESCRIPTION
## Summary
- add reusable hook for fetching and storing puzzle hints
- simplify NeedHintButton to use new hook
- cover hint flow with a hook test

## Testing
- `yarn lint:fix`
- `yarn web:ci`
- `git secrets --scan`

Closes #0

------
https://chatgpt.com/codex/tasks/task_e_689080c0c00c8326ac30d335da80ac82

## Summary by Sourcery

Add a reusable client-side hook for generating and storing puzzle hints, simplify the NeedHintButton component to use this hook, and cover the hint flow with a dedicated unit test

New Features:
- Introduce useHint hook to fetch and store puzzle hints

Enhancements:
- Refactor NeedHintButton to delegate hint logic to the useHint hook

Tests:
- Add unit test for useHint to verify hint generation and addition to game clues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new hint management feature, allowing users to fetch hints more seamlessly during gameplay.

* **Refactor**
  * Improved the hint button by delegating hint fetching and state management to a dedicated hook, resulting in a cleaner and more maintainable interface.

* **Tests**
  * Added comprehensive tests to ensure the new hint functionality works correctly within the game context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->