### PR TITLE
feat(ui): add hint widget component

### DIFF
--- a/packages/ui/src/__tests__/HintWidget.test.tsx
+++ b/packages/ui/src/__tests__/HintWidget.test.tsx
@@ -1,0 +1,21 @@
+import { fireEvent, render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { HintWidget } from '../components/HintWidget';
+
+describe('HintWidget', () => {
+  it('reveals hints sequentially', () => {
+    const hints = ['First', 'Second'];
+    const { getByRole, getByText, queryByText, queryByRole } = render(
+      <HintWidget hints={hints} />,
+    );
+
+    expect(queryByText('First')).toBeNull();
+    fireEvent.click(getByRole('button', { name: /show hint/i }));
+    expect(getByText('First')).toBeInTheDocument();
+    fireEvent.click(getByRole('button', { name: /show hint/i }));
+    expect(getByText('Second')).toBeInTheDocument();
+    expect(queryByRole('button', { name: /show hint/i })).toBeNull();
+  });
+});

--- a/packages/ui/src/components/HintWidget.tsx
+++ b/packages/ui/src/components/HintWidget.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import React from 'react';
+import { cn } from '@utils/cn';
+import { Button } from './Button';
+
+export type HintWidgetProps = {
+  /** Ordered list of hints */
+  hints: string[];
+  /** Called whenever a hint is revealed */
+  onReveal?: (hint: string, index: number) => void;
+} & React.HTMLAttributes<HTMLDivElement>;
+
+/**
+ * Widget displaying sequential gameplay hints.
+ */
+export function HintWidget({
+  hints,
+  onReveal,
+  className,
+  ...props
+}: HintWidgetProps) {
+  const [index, setIndex] = React.useState<number | null>(null);
+
+  const handleReveal = () => {
+    const next = index === null ? 0 : index + 1;
+    if (next >= hints.length) return;
+    setIndex(next);
+    onReveal?.(hints[next], next);
+  };
+
+  const showButton = index === null || index < hints.length - 1;
+  return (
+    <div {...props} className={cn('space-y-2', className)}>
+      {index !== null && (
+        <p aria-live="polite" aria-atomic="true" className="text-sm">
+          {hints[index]}
+        </p>
+      )}
+      {showButton && <Button label="Show hint 💡" onClick={handleReveal} />}
+    </div>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,5 +1,6 @@
 export * from './components/Button';
 export * from './components/ChoiceButton';
 export * from './components/StatusSidebar';
+export * from './components/HintWidget';
 export * from './hooks/useStoryClient';
 export * from './hooks/useGameContext';


### PR DESCRIPTION
## Summary
- add hint widget for sequentially revealing hints
- test hint widget interactions

## Testing
- `yarn lint:fix`
- `yarn test`

Closes #123

------
https://chatgpt.com/codex/tasks/task_e_68908739bc5483269253fb2cce884baa

## Summary by Sourcery

Add a new HintWidget component to display hints one at a time with a reveal button and an onReveal callback, and include corresponding interaction tests.

New Features:
- Introduce a HintWidget component for sequentially revealing gameplay hints
- Export the HintWidget from the UI package index

Tests:
- Add unit tests covering hint revealing interactions in the HintWidget

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new HintWidget component for displaying sequential gameplay hints, including accessibility support and custom styling options.

* **Tests**
  * Added tests to verify the HintWidget's behaviour when revealing hints step by step.

* **Documentation**
  * Made the HintWidget component publicly available for import in the UI package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->