### PR TITLE
feat(utils): introduce storylet engine utility

### DIFF
--- a/packages/utils/src/__tests__/storylet-engine.test.ts
+++ b/packages/utils/src/__tests__/storylet-engine.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createStoryletEngine,
+  type Storylet,
+} from '../storylet-engine';
+
+describe('storylet engine', () => {
+  interface State {
+    score: number;
+  }
+  type Id = 'start' | 'mid' | 'end';
+
+  const storylets: Storylet<State, Id>[] = [
+    { id: 'start', weight: 1, when: (s) => s.score >= 0 },
+    { id: 'mid', weight: 2, when: (s) => s.score > 5 },
+    { id: 'end', when: (s) => s.score > 10 },
+  ];
+
+  it('filters storylets by conditions', () => {
+    const engine = createStoryletEngine<State, Id>({
+      storylets,
+      random: () => 0,
+    });
+    const available = engine.available({ score: 7 }).map((s) => s.id);
+    expect(available).toEqual(['start', 'mid']);
+  });
+
+  it('selects storylets using weights', () => {
+    const engine = createStoryletEngine<State, Id>({
+      storylets,
+      random: () => 0.75,
+    });
+    expect(engine.select({ score: 6 })?.id).toBe('mid');
+  });
+
+  it('returns undefined when none available', () => {
+    const engine = createStoryletEngine<State, Id>({
+      storylets,
+      random: () => 0,
+    });
+    expect(engine.select({ score: -1 })).toBeUndefined();
+  });
+});

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -3,4 +3,5 @@ export * from './state-machine';
 export * from './supabase';
 export * from './database.types';
 export * from './story-runner';
+export * from './storylet-engine';
 export type { StoryYield } from './story-runner';

--- a/packages/utils/src/storylet-engine.ts
+++ b/packages/utils/src/storylet-engine.ts
@@ -1,0 +1,62 @@
+/**
+ * Lightweight engine to pick the next storylet.
+ */
+
+export interface Storylet<TState, TId extends string> {
+  /** Unique identifier. */
+  readonly id: TId;
+  /** Selection weight. Defaults to 1. */
+  readonly weight?: number;
+  /** Availability predicate. */
+  readonly when?: (state: TState) => boolean;
+}
+
+export interface StoryletEngineConfig<TState, TId extends string> {
+  /** Pool of storylets to evaluate. */
+  readonly storylets: ReadonlyArray<Storylet<TState, TId>>;
+  /** Source of randomness. */
+  readonly random?: () => number;
+}
+
+export interface StoryletEngine<TState, TId extends string> {
+  /** List storylets available for the given state. */
+  available(state: TState): Storylet<TState, TId>[];
+  /** Select one storylet using weighted randomness. */
+  select(state: TState): Storylet<TState, TId> | undefined;
+}
+
+/**
+ * Create a storylet engine.
+ *
+ * @param config - Engine configuration.
+ * @returns Engine API.
+ */
+export function createStoryletEngine<
+  TState,
+  TId extends string,
+>(config: StoryletEngineConfig<TState, TId>): StoryletEngine<TState, TId> {
+  const { storylets, random = Math.random } = config;
+
+  const available = (state: TState): Storylet<TState, TId>[] =>
+    storylets.filter((s) => (s.when ? s.when(state) : true));
+
+  const select = (state: TState): Storylet<TState, TId> | undefined => {
+    const pool = available(state);
+    if (pool.length === 0) {
+      return undefined;
+    }
+
+    const total = pool.reduce((sum, s) => sum + (s.weight ?? 1), 0);
+    let roll = random() * total;
+    for (const s of pool) {
+      roll -= s.weight ?? 1;
+      if (roll < 0) {
+        return s;
+      }
+    }
+    return pool[pool.length - 1];
+  };
+
+  return { available, select };
+}
+


### PR DESCRIPTION
## Summary
- add storylet engine for weighted storylet selection
- expose engine from utils package
- test storylet selection logic

Closes #123


------
https://chatgpt.com/codex/tasks/task_e_6891958032d08326b72496ae3620bcf1

## Summary by Sourcery

Introduce a storylet engine utility for weighted storylet selection in the utils package

New Features:
- Add createStoryletEngine for weighted and conditional storylet selection

Enhancements:
- Expose storylet-engine module in utils index

Tests:
- Add unit tests for storylet-engine availability filtering and weighted selection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a lightweight storylet engine for managing and selecting storylets based on state and weighted randomness.
* **Tests**
  * Added comprehensive tests to verify storylet filtering and weighted selection behaviour.
* **Chores**
  * Expanded the public API to include the new storylet engine module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->