### PR TITLE
feat(ui): add useStorylet hook

### DIFF
--- a/packages/ui/src/__tests__/useStorylet.test.tsx
+++ b/packages/ui/src/__tests__/useStorylet.test.tsx
@@ -1,0 +1,43 @@
+import { act, renderHook } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, it } from 'vitest';
+import type { Storylet } from '@utils/storylet-engine';
+import { useStorylet } from '../hooks/useStorylet';
+
+interface State {
+  readonly flag: boolean;
+}
+
+type Id = 'a' | 'b';
+
+const storylets: ReadonlyArray<Storylet<State, Id>> = [
+  { id: 'a', when: (s) => s.flag },
+  { id: 'b' },
+];
+
+describe('useStorylet', () => {
+  it('selects available storylets by state', () => {
+    const random = () => 0; // always pick first available
+
+    const { result, rerender } = renderHook(
+      ({ flag }) => useStorylet({ storylets, random }, { flag }),
+      { initialProps: { flag: true } },
+    );
+
+    expect(result.current.available.map((s) => s.id)).toEqual(['a', 'b']);
+
+    act(() => {
+      result.current.roll();
+    });
+    expect(result.current.current?.id).toBe('a');
+
+    rerender({ flag: false });
+    expect(result.current.available.map((s) => s.id)).toEqual(['b']);
+
+    act(() => {
+      result.current.roll();
+    });
+    expect(result.current.current?.id).toBe('b');
+  });
+});
+

--- a/packages/ui/src/hooks/useStorylet.ts
+++ b/packages/ui/src/hooks/useStorylet.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import type { Storylet, StoryletEngineConfig } from '@utils/storylet-engine';
+import { createStoryletEngine } from '@utils/storylet-engine';
+
+export interface UseStoryletReturn<TState, TId extends string> {
+  /** List of currently available storylets. */
+  readonly available: Storylet<TState, TId>[];
+  /** Currently selected storylet. */
+  readonly current?: Storylet<TState, TId>;
+  /** Select a new storylet using weighted randomness. */
+  readonly roll: () => void;
+}
+
+/**
+ * React hook to evaluate and select storylets based on state.
+ *
+ * @param config - Engine configuration.
+ * @param state - Current world state used to evaluate availability.
+ * @returns List of available storylets, current selection, and roll helper.
+ */
+export function useStorylet<TState, TId extends string>(
+  config: StoryletEngineConfig<TState, TId>,
+  state: TState,
+): UseStoryletReturn<TState, TId> {
+  const engine = useMemo(
+    () => createStoryletEngine(config),
+    [config],
+  );
+  const available = useMemo(() => engine.available(state), [engine, state]);
+  const [current, setCurrent] = useState<Storylet<TState, TId>>();
+
+  const roll = useCallback(() => {
+    setCurrent(engine.select(state));
+  }, [engine, state]);
+
+  return { available, current, roll };
+}
+

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -4,3 +4,4 @@ export * from './components/StatusSidebar';
 export * from './components/HintWidget';
 export * from './hooks/useStoryClient';
 export * from './hooks/useGameContext';
+export * from './hooks/useStorylet';


### PR DESCRIPTION
## Summary
- add `useStorylet` hook for selecting storylets based on state
- export hook from UI package

## Testing
- `yarn lint:fix`
- `yarn test`

Closes #1

------
https://chatgpt.com/codex/tasks/task_e_689198ce59f88326b107d78266483c65

## Summary by Sourcery

Introduce a useStorylet hook in the UI package to manage storylet availability and selection based on state, export it from the entry point, and cover its behavior with unit tests.

New Features:
- Add useStorylet hook for evaluating and selecting storylets based on application state
- Export useStorylet hook from the UI package entry point

Tests:
- Add unit tests for useStorylet to verify availability and random selection behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new hook that enables selection and management of storylets based on application state.
* **Tests**
  * Added comprehensive tests to ensure correct filtering and selection behaviour for storylets.
* **Chores**
  * Made the new hook available for import from the main package entry point.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->