### PR TITLE
feat: integrate hint widget with game provider

### DIFF
--- a/packages/ui/src/__tests__/HintWidget.test.tsx
+++ b/packages/ui/src/__tests__/HintWidget.test.tsx
@@ -1,21 +1,30 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
 import { describe, expect, it } from 'vitest';
 import { HintWidget } from '../components/HintWidget';
+import { StatusSidebar } from '../components/StatusSidebar';
+import { GameProvider } from '../hooks/useGameContext';
 
 describe('HintWidget', () => {
-  it('reveals hints sequentially', () => {
+  it('reveals hints sequentially and stores them in game provider', () => {
     const hints = ['First', 'Second'];
-    const { getByRole, getByText, queryByText, queryByRole } = render(
-      <HintWidget hints={hints} />,
+    const { getByRole, queryByRole, getByLabelText } = render(
+      <GameProvider>
+        <HintWidget hints={hints} aria-label="hint widget" />
+        <StatusSidebar aria-label="game status sidebar" />
+      </GameProvider>,
     );
 
-    expect(queryByText('First')).toBeNull();
+    const widget = getByLabelText('hint widget');
+    expect(within(widget).queryByText('First')).toBeNull();
     fireEvent.click(getByRole('button', { name: /show hint/i }));
-    expect(getByText('First')).toBeInTheDocument();
+    expect(within(widget).getByText('First')).toBeInTheDocument();
+    const sidebar = getByLabelText('game status sidebar');
+    expect(within(sidebar).getByText('First')).toBeInTheDocument();
     fireEvent.click(getByRole('button', { name: /show hint/i }));
-    expect(getByText('Second')).toBeInTheDocument();
+    expect(within(widget).getByText('Second')).toBeInTheDocument();
+    expect(within(sidebar).getByText('Second')).toBeInTheDocument();
     expect(queryByRole('button', { name: /show hint/i })).toBeNull();
   });
 });

--- a/packages/ui/src/components/HintWidget.tsx
+++ b/packages/ui/src/components/HintWidget.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { cn } from '@utils/cn';
+import { useGame } from '../hooks/useGameContext';
 import { Button } from './Button';
 
 export type HintWidgetProps = {
@@ -13,6 +14,8 @@ export type HintWidgetProps = {
 
 /**
  * Widget displaying sequential gameplay hints.
+ *
+ * Revealed hints are added to the game provider clues.
  */
 export function HintWidget({
   hints,
@@ -20,13 +23,16 @@ export function HintWidget({
   className,
   ...props
 }: HintWidgetProps) {
+  const { addClue } = useGame();
   const [index, setIndex] = React.useState<number | null>(null);
 
   const handleReveal = () => {
     const next = index === null ? 0 : index + 1;
     if (next >= hints.length) return;
     setIndex(next);
-    onReveal?.(hints[next], next);
+    const hint = hints[next];
+    addClue(hint);
+    onReveal?.(hint, next);
   };
 
   const showButton = index === null || index < hints.length - 1;


### PR DESCRIPTION
## Summary
- integrate HintWidget with GameProvider to record revealed hints as clues

## Testing
- `yarn lint:fix`
- `yarn test`
- `git secrets --scan`

Closes #123

------
https://chatgpt.com/codex/tasks/task_e_68919f05e3808326a5b3937496d54397

## Summary by Sourcery

Integrate HintWidget with GameProvider to automatically record revealed hints as game clues

New Features:
- Record revealed hints in game context via addClue when HintWidget reveals a hint

Tests:
- Update HintWidget tests to mock GameProvider and verify addClue is invoked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Revealed hints in the HintWidget are now synchronised with the game state and also displayed in the StatusSidebar.

* **Tests**
  * Enhanced tests to verify that revealed hints appear both in the HintWidget and the StatusSidebar, ensuring correct integration with the game context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->