### PR TITLE
feat: add fade-in paragraph component

### DIFF
--- a/apps/web/src/components/GameClient.tsx
+++ b/apps/web/src/components/GameClient.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useRef } from 'react';
 import { Button } from '@ui/components/Button';
 import { ChoiceButton } from '@ui/components/ChoiceButton';
+import { FadeInParagraph } from '@ui/components/FadeInParagraph';
 import { useGame } from '@ui/hooks/useGameContext';
 import { cn } from '@utils/cn';
 import { useGameMachine } from '@/lib/useGameMachine';
@@ -64,11 +65,11 @@ export function GameClient({ className, ...props }: GameClientProps) {
       className={cn('flex flex-col items-center gap-4 py-8', className)}
       {...props}
     >
-      <p aria-live="polite" aria-atomic="true">
+      <FadeInParagraph aria-live="polite" aria-atomic="true">
         {state === 'playing' && path
           ? `Path ${path.toUpperCase()} selected`
           : messages[state]}
-      </p>
+      </FadeInParagraph>
       <div>
         {state === 'intro' && (
           <Button

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { Button } from '@ui/components/Button';
+import { FadeInParagraph } from '@ui/components/FadeInParagraph';
 
 /**
  * Hero section displayed on the home page.
@@ -14,9 +15,9 @@ export function HomeHero() {
       className="flex flex-col items-center gap-6 py-16 text-center"
     >
       <h1 className="text-4xl font-bold">Welcome to Echoes of Control</h1>
-      <p className="text-lg text-gray-600 dark:text-gray-400">
+      <FadeInParagraph className="text-lg text-gray-600 dark:text-gray-400">
         A replay-friendly, text-first investigation game.
-      </p>
+      </FadeInParagraph>
       <Button
         href="/"
         label="Start Exploring 🚀"

--- a/packages/ui/eslint.config.mjs
+++ b/packages/ui/eslint.config.mjs
@@ -14,6 +14,11 @@ export default [
   ...baseConfig,
   ...compat.extends('next/core-web-vitals', 'next/typescript'),
   {
+    settings: {
+      next: {
+        rootDir: '../../apps/web',
+      },
+    },
     rules: {
       'next/no-html-link-for-pages': 'off',
     },

--- a/packages/ui/src/__tests__/FadeInParagraph.test.tsx
+++ b/packages/ui/src/__tests__/FadeInParagraph.test.tsx
@@ -1,0 +1,44 @@
+import { act, render, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { describe, expect, it, beforeEach } from 'vitest';
+import { FadeInParagraph } from '../components/FadeInParagraph';
+
+describe('FadeInParagraph', () => {
+  let callbacks: IntersectionObserverCallback[] = [];
+
+  beforeEach(() => {
+    callbacks = [];
+    globalThis.IntersectionObserver = class {
+      callback: IntersectionObserverCallback;
+      constructor(cb: IntersectionObserverCallback) {
+        this.callback = cb;
+        callbacks.push(cb);
+      }
+      observe() {}
+      disconnect() {}
+      takeRecords() {
+        return [];
+      }
+      unobserve() {}
+      root = null;
+      rootMargin = '';
+      thresholds = [];
+    } as unknown as typeof IntersectionObserver;
+  });
+
+  it('fades in once intersecting', async () => {
+    const { getByText } = render(
+      <FadeInParagraph>Hello</FadeInParagraph>,
+    );
+    const p = getByText('Hello');
+    expect(p).toHaveClass('opacity-0');
+    await act(async () => {
+      callbacks[0]([
+        { isIntersecting: true } as IntersectionObserverEntry,
+      ],
+      null as unknown as IntersectionObserver);
+    });
+    await waitFor(() => expect(p).toHaveClass('opacity-100'));
+  });
+});

--- a/packages/ui/src/components/FadeInParagraph.tsx
+++ b/packages/ui/src/components/FadeInParagraph.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import { cn } from '@utils/cn';
+
+/**
+ * Paragraph that fades in when it enters the viewport.
+ */
+export type FadeInParagraphProps = React.HTMLAttributes<HTMLParagraphElement>;
+
+export function FadeInParagraph({ className, children, ...props }: FadeInParagraphProps) {
+  const ref = useRef<HTMLParagraphElement>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+
+    if (typeof IntersectionObserver === 'undefined') {
+      setVisible(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        setVisible(true);
+        observer.disconnect();
+      }
+    });
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <p
+      ref={ref}
+      className={cn(
+        'opacity-0 transition-opacity duration-700',
+        visible && 'opacity-100',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </p>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,6 +3,7 @@ export * from './components/ChoiceButton';
 export * from './components/StatusSidebar';
 export * from './components/HintWidget';
 export * from './components/StoryletCard';
+export * from './components/FadeInParagraph';
 export * from './hooks/useStoryClient';
 export * from './hooks/useGameContext';
 export * from './hooks/useStorylet';


### PR DESCRIPTION
## Summary
- add reusable fade-in paragraph component
- apply fade-in to home and game status text
- configure UI eslint settings for Next.js root

## Testing
- `yarn lint:fix`
- `yarn test`
- `yarn e2e`
- `yarn web:ci`


------
https://chatgpt.com/codex/tasks/task_e_6891b2b750f883269650fb2715d13c1d