### PR TITLE
feat(ui): add hover and press animation to ChoiceButton

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,20 +13,22 @@
     "test": "vitest run"
   },
   "peerDependencies": {
+    "framer-motion": "^12.23.12",
     "react": "^19",
     "react-dom": "^19"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
+    "framer-motion": "^12.23.12",
     "jsdom": "^26.1.0",
-    "typescript": "^5",
-    "vitest": "^3.2.4",
     "tailwindcss": "^4",
-    "@tailwindcss/postcss": "^4"
+    "typescript": "^5",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/ui/src/__tests__/ChoiceButton.test.tsx
+++ b/packages/ui/src/__tests__/ChoiceButton.test.tsx
@@ -14,4 +14,12 @@ describe('ChoiceButton', () => {
     fireEvent.click(button);
     expect(onSelect).toHaveBeenCalledTimes(1);
   });
+
+  it('marks the button as pressed when selected', () => {
+    const { getByRole } = render(
+      <ChoiceButton label="Pick" selected />,
+    );
+    const button = getByRole('button', { name: /pick/i });
+    expect(button).toHaveAttribute('aria-pressed', 'true');
+  });
 });

--- a/packages/ui/src/components/ChoiceButton.tsx
+++ b/packages/ui/src/components/ChoiceButton.tsx
@@ -1,13 +1,17 @@
 'use client';
 
 import React from 'react';
+import { motion } from 'framer-motion';
 import { cn } from '@utils/cn';
 import { Button } from './Button';
+
+const MotionButton = motion.create(Button);
 
 /**
  * Button for selecting a choice.
  *
  * Adds `aria-pressed` to show selected state.
+ * Uses Framer Motion to animate hover and press.
  */
 export type ChoiceButtonProps = {
   /** Button label */
@@ -39,13 +43,15 @@ export const ChoiceButton = React.forwardRef<HTMLButtonElement, ChoiceButtonProp
     };
 
     return (
-      <Button
+      <MotionButton
         {...props}
         ref={ref}
         label={label}
         aria-pressed={selected}
         className={classes}
         onClick={handleClick}
+        whileHover={{ scale: 1.05 }}
+        whileTap={{ scale: 0.95 }}
       />
     );
   },


### PR DESCRIPTION
## Summary
- add Framer Motion hover and press animations to `ChoiceButton`
- declare Framer Motion peer and dev dependencies
- test `ChoiceButton` selected state

## Testing
- `yarn workspace ui lint --fix`
- `yarn workspace ui test`

Closes #123

------
https://chatgpt.com/codex/tasks/task_e_6891fd3e82b883269388ce3bfd21493e

## Summary by Sourcery

Enable Framer Motion hover and press animations for ChoiceButton, declare framer-motion in dependencies, and add a test for the selected state.

New Features:
- Animate ChoiceButton on hover and press using Framer Motion

Enhancements:
- Add framer-motion as a peer and dev dependency

Tests:
- Add test to verify ChoiceButton's aria-pressed attribute when selected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive animations to the ChoiceButton component, providing visual feedback when hovering or pressing the button.

* **Tests**
  * Introduced a new test to ensure the ChoiceButton correctly sets the aria-pressed attribute when selected.

* **Chores**
  * Updated dependencies to include framer-motion and reorganised devDependencies for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->