### PR TITLE
feat: animate choice button

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -14,7 +14,8 @@
   },
   "peerDependencies": {
     "react": "^19",
-    "react-dom": "^19"
+    "react-dom": "^19",
+    "framer-motion": "^12.23.12"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -23,6 +24,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
+    "framer-motion": "^12.23.12",
     "jsdom": "^26.1.0",
     "typescript": "^5",
     "vitest": "^3.2.4",

--- a/packages/ui/src/__tests__/ChoiceButton.test.tsx
+++ b/packages/ui/src/__tests__/ChoiceButton.test.tsx
@@ -14,4 +14,12 @@ describe('ChoiceButton', () => {
     fireEvent.click(button);
     expect(onSelect).toHaveBeenCalledTimes(1);
   });
+
+  it('marks selection via aria-pressed', () => {
+    const { getByRole } = render(
+      <ChoiceButton label="Pick" selected />,
+    );
+    const button = getByRole('button', { name: /pick/i });
+    expect(button).toHaveAttribute('aria-pressed', 'true');
+  });
 });

--- a/packages/ui/src/components/ChoiceButton.tsx
+++ b/packages/ui/src/components/ChoiceButton.tsx
@@ -1,11 +1,10 @@
 'use client';
 
 import React from 'react';
-import { motion } from 'framer-motion';
+import { motion, type HTMLMotionProps } from 'framer-motion';
 import { cn } from '@utils/cn';
-import { Button } from './Button';
 
-const MotionButton = motion.create(Button);
+const MotionButton = motion.button;
 
 /**
  * Button for selecting a choice.
@@ -20,7 +19,7 @@ export type ChoiceButtonProps = {
   selected?: boolean;
   /** Called after selection */
   onSelect?: () => void;
-} & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children'>;
+} & Omit<HTMLMotionProps<'button'>, 'children'>;
 
 export const ChoiceButton = React.forwardRef<HTMLButtonElement, ChoiceButtonProps>(
   function ChoiceButton(
@@ -46,13 +45,15 @@ export const ChoiceButton = React.forwardRef<HTMLButtonElement, ChoiceButtonProp
       <MotionButton
         {...props}
         ref={ref}
-        label={label}
+        type="button"
         aria-pressed={selected}
         className={classes}
         onClick={handleClick}
         whileHover={{ scale: 1.05 }}
         whileTap={{ scale: 0.95 }}
-      />
+      >
+        {label}
+      </MotionButton>
     );
   },
 );

--- a/packages/ui/src/components/ChoiceButton.tsx
+++ b/packages/ui/src/components/ChoiceButton.tsx
@@ -1,13 +1,17 @@
 'use client';
 
 import React from 'react';
+import { motion } from 'framer-motion';
 import { cn } from '@utils/cn';
 import { Button } from './Button';
+
+const MotionButton = motion.create(Button);
 
 /**
  * Button for selecting a choice.
  *
  * Adds `aria-pressed` to show selected state.
+ * Animates scale on hover and press.
  */
 export type ChoiceButtonProps = {
   /** Button label */
@@ -39,13 +43,15 @@ export const ChoiceButton = React.forwardRef<HTMLButtonElement, ChoiceButtonProp
     };
 
     return (
-      <Button
+      <MotionButton
         {...props}
         ref={ref}
         label={label}
         aria-pressed={selected}
         className={classes}
         onClick={handleClick}
+        whileHover={{ scale: 1.05 }}
+        whileTap={{ scale: 0.95 }}
       />
     );
   },


### PR DESCRIPTION
## Summary
- animate ChoiceButton on hover and press with Framer Motion
- expose framer-motion in ui package
- test ChoiceButton selection state

## Testing
- `yarn lint:fix`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6891fd3e82b883269388ce3bfd21493e

## Summary by Sourcery

Integrate Framer Motion into the ChoiceButton component to animate hover and press interactions, update package dependencies accordingly, and add a test for the selection state.

New Features:
- Animate ChoiceButton scale on hover and press using Framer Motion

Enhancements:
- Expose framer-motion as a dependency in the ui package

Build:
- Add framer-motion to peerDependencies and devDependencies in ui package.json

Tests:
- Add aria-pressed test for ChoiceButton selection state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added animation effects to the ChoiceButton component, including scaling on hover and tap for enhanced interactivity.

* **Chores**
  * Added framer-motion as a dependency for improved animation support.

* **Tests**
  * Introduced a new test to verify accessibility attributes when the ChoiceButton is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->