### PR TITLE
feat: add status HUD progress bar

### DIFF
--- a/apps/web/src/components/__tests__/GameSidebar.test.tsx
+++ b/apps/web/src/components/__tests__/GameSidebar.test.tsx
@@ -7,12 +7,13 @@ import { GameSidebar } from '../GameSidebar';
 
 describe('GameSidebar', () => {
   it('shows default status and no clues', () => {
-    const { getByText } = render(
+    const { getByText, getByRole } = render(
       <GameProvider>
         <GameSidebar />
       </GameProvider>,
     );
     expect(getByText(/idle/i)).toBeInTheDocument();
     expect(getByText(/no clues yet/i)).toBeInTheDocument();
+    expect(getByRole('progressbar')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/__tests__/ProgressBar.test.tsx
+++ b/packages/ui/src/__tests__/ProgressBar.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { ProgressBar } from '../components/ProgressBar';
+
+describe('ProgressBar', () => {
+  it('renders with correct value attributes', () => {
+    const { getByRole } = render(<ProgressBar value={2} max={4} />);
+    const bar = getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '2');
+    expect(bar).toHaveAttribute('aria-valuemax', '4');
+  });
+});

--- a/packages/ui/src/__tests__/StatusSidebar.test.tsx
+++ b/packages/ui/src/__tests__/StatusSidebar.test.tsx
@@ -16,12 +16,13 @@ describe('StatusSidebar', () => {
         return <StatusSidebar />;
       }
 
-      const { getByText } = render(
-        <GameProvider>
-          <Setup />
-        </GameProvider>,
-      );
-      expect(getByText('Investigating')).toBeInTheDocument();
-      expect(getByText('Found note')).toBeInTheDocument();
-    });
+    const { getByText, getByRole } = render(
+      <GameProvider>
+        <Setup />
+      </GameProvider>,
+    );
+    expect(getByText('Investigating')).toBeInTheDocument();
+    expect(getByText('Found note')).toBeInTheDocument();
+    expect(getByRole('progressbar')).toBeInTheDocument();
   });
+});

--- a/packages/ui/src/components/ProgressBar.tsx
+++ b/packages/ui/src/components/ProgressBar.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import React from 'react';
+import { cn } from '@utils/cn';
+
+/**
+ * Accessible progress bar.
+ */
+export interface ProgressBarProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Current progress value. */
+  value: number;
+  /** Maximum progress value. */
+  max: number;
+}
+
+export function ProgressBar({ value, max, className, ...props }: ProgressBarProps) {
+  const percent = max > 0 ? Math.min((value / max) * 100, 100) : 0;
+
+  return (
+    <div
+      role="progressbar"
+      aria-valuenow={value}
+      aria-valuemin={0}
+      aria-valuemax={max}
+      className={cn('h-2 w-full rounded bg-gray-200', className)}
+      {...props}
+    >
+      <div
+        className="h-full rounded bg-blue-500"
+        style={{ width: `${percent}%` }}
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/components/StatusSidebar.tsx
+++ b/packages/ui/src/components/StatusSidebar.tsx
@@ -3,13 +3,17 @@
 import React from 'react';
 import { cn } from '@utils/cn';
 import { useGame } from '../hooks/useGameContext';
+import { ProgressBar } from './ProgressBar';
 
 /**
  * Sidebar panel showing the player's current status and discovered clues.
  */
-export type StatusSidebarProps = React.HTMLAttributes<HTMLElement>;
+export interface StatusSidebarProps extends React.HTMLAttributes<HTMLElement> {
+  /** Total clues available. */
+  totalClues?: number;
+}
 
-export function StatusSidebar({ className, ...props }: StatusSidebarProps) {
+export function StatusSidebar({ className, totalClues = 3, ...props }: StatusSidebarProps) {
   const { status, clues } = useGame();
   return (
     <aside
@@ -21,9 +25,13 @@ export function StatusSidebar({ className, ...props }: StatusSidebarProps) {
     >
       <div>
         <h2 className="text-lg font-semibold">Status</h2>
-        <p aria-live="polite" aria-atomic="true">
-          {status}
-        </p>
+        <p aria-live="polite" aria-atomic="true">{status}</p>
+        <ProgressBar
+          value={clues.length}
+          max={totalClues}
+          aria-label="Clue progress"
+          className="mt-2"
+        />
       </div>
       <div>
         <h2 className="text-lg font-semibold">Clues</h2>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -6,3 +6,4 @@ export * from './components/StoryletCard';
 export * from './hooks/useStoryClient';
 export * from './hooks/useGameContext';
 export * from './hooks/useStorylet';
+export * from './components/ProgressBar';


### PR DESCRIPTION
## Summary
- add reusable ProgressBar component
- show clue progress in StatusSidebar
- cover progress visuals with unit tests

## Testing
- `yarn lint:fix`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_689325c5b8a48326a72c2aa27e1ff5ee

## Summary by Sourcery

Add an accessible ProgressBar component and embed it in the StatusSidebar to visually represent clue progress, and update tests to cover the new progress bar functionality

New Features:
- Add reusable accessible ProgressBar component
- Integrate ProgressBar into StatusSidebar with configurable totalClues prop

Tests:
- Add unit tests for ProgressBar visuals
- Update StatusSidebar and GameSidebar tests to assert progressbar presence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a visual and accessible progress bar component for tracking progress.
  * Enhanced the status sidebar to display a progress indicator for clues.

* **Bug Fixes**
  * Improved accessibility by ensuring progress indicators are properly labelled and rendered.

* **Tests**
  * Added and updated tests to verify the presence and correct behaviour of progress bars in relevant components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->