### PR TITLE
feat: add status HUD audio cues

### DIFF
--- a/packages/ui/eslint.config.mjs
+++ b/packages/ui/eslint.config.mjs
@@ -14,6 +14,11 @@ export default [
   ...baseConfig,
   ...compat.extends('next/core-web-vitals', 'next/typescript'),
   {
+    settings: {
+      next: {
+        rootDir: '../../apps/web',
+      },
+    },
     rules: {
       'next/no-html-link-for-pages': 'off',
     },

--- a/packages/ui/src/__tests__/StatusSidebar.test.tsx
+++ b/packages/ui/src/__tests__/StatusSidebar.test.tsx
@@ -31,7 +31,32 @@ describe('StatusSidebar', () => {
     expect(getByRole('progressbar')).toBeInTheDocument();
   });
 
+  it('does not play sound on initial render', () => {
+    vi.useFakeTimers();
+    function Setup() {
+      const { setStatus, addClue } = useGame();
+      React.useEffect(() => {
+        setStatus('Investigating');
+        addClue('Found note');
+      }, [setStatus, addClue]);
+      return <StatusSidebar />;
+    }
+
+    const spy = vi
+      .spyOn(sound, 'playStatusSound')
+      .mockImplementation(() => {});
+    render(
+      <GameProvider>
+        <Setup />
+      </GameProvider>,
+    );
+    expect(spy).not.toHaveBeenCalled();
+    vi.runAllTimers();
+    vi.useRealTimers();
+  });
+
   it('plays sound on status or clue change', () => {
+    vi.useFakeTimers();
     let api: GameContextValue;
     function Setup() {
       api = useGame();
@@ -46,6 +71,8 @@ describe('StatusSidebar', () => {
       </GameProvider>,
     );
 
+    vi.runAllTimers();
+
     act(() => {
       api.setStatus('Investigating');
     });
@@ -55,5 +82,6 @@ describe('StatusSidebar', () => {
       api.addClue('Found note');
     });
     expect(spy).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
   });
 });

--- a/packages/ui/src/components/StatusSidebar.tsx
+++ b/packages/ui/src/components/StatusSidebar.tsx
@@ -19,16 +19,23 @@ export interface StatusSidebarProps extends React.HTMLAttributes<HTMLElement> {
 export function StatusSidebar({ className, totalClues = 3, ...props }: StatusSidebarProps) {
   const { status, clues } = useGame();
   const prev = React.useRef({ status, clueCount: clues.length });
+  const ready = React.useRef(false);
 
   React.useEffect(() => {
-    if (
-      prev.current.status !== status ||
-      prev.current.clueCount !== clues.length
-    ) {
-      playStatusSound();
-      prev.current = { status, clueCount: clues.length };
-    }
+    const changed =
+      prev.current.status !== status || prev.current.clueCount !== clues.length;
+    if (!changed) return;
+
+    if (ready.current) playStatusSound();
+    prev.current = { status, clueCount: clues.length };
   }, [status, clues.length]);
+
+  React.useEffect(() => {
+    const id = setTimeout(() => {
+      ready.current = true;
+    });
+    return () => clearTimeout(id);
+  }, []);
 
   return (
     <aside

--- a/packages/ui/src/components/StatusSidebar.tsx
+++ b/packages/ui/src/components/StatusSidebar.tsx
@@ -3,10 +3,13 @@
 import React from 'react';
 import { cn } from '@utils/cn';
 import { useGame } from '../hooks/useGameContext';
+import { playStatusSound } from '../lib/sound';
 import { ProgressBar } from './ProgressBar';
 
 /**
  * Sidebar panel showing the player's current status and discovered clues.
+ *
+ * Plays a gentle beep when the status or clue count changes.
  */
 export interface StatusSidebarProps extends React.HTMLAttributes<HTMLElement> {
   /** Total clues available. */
@@ -15,6 +18,18 @@ export interface StatusSidebarProps extends React.HTMLAttributes<HTMLElement> {
 
 export function StatusSidebar({ className, totalClues = 3, ...props }: StatusSidebarProps) {
   const { status, clues } = useGame();
+  const prev = React.useRef({ status, clueCount: clues.length });
+
+  React.useEffect(() => {
+    if (
+      prev.current.status !== status ||
+      prev.current.clueCount !== clues.length
+    ) {
+      playStatusSound();
+      prev.current = { status, clueCount: clues.length };
+    }
+  }, [status, clues.length]);
+
   return (
     <aside
       {...props}

--- a/packages/ui/src/lib/sound.ts
+++ b/packages/ui/src/lib/sound.ts
@@ -1,0 +1,34 @@
+'use client';
+
+let ctx: AudioContext | undefined;
+
+/**
+ * Play a gentle beep to highlight status changes.
+ */
+export function playStatusSound() {
+  if (typeof window === 'undefined') return;
+
+  const AudioCtx =
+    window.AudioContext ||
+    (window as Window & { webkitAudioContext?: typeof AudioContext })
+      .webkitAudioContext;
+  if (!AudioCtx) return;
+
+  ctx = ctx ?? new AudioCtx();
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+
+  osc.type = 'sine';
+  osc.frequency.value = 880;
+  gain.gain.value = 0.05;
+
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+
+  osc.start();
+  osc.stop(ctx.currentTime + 0.12);
+  osc.addEventListener('ended', () => {
+    osc.disconnect();
+    gain.disconnect();
+  });
+}


### PR DESCRIPTION
## Summary
- beep when player status or clues update
- wire status sidebar to play subtle sound cues
- cover status sounds with tests and lint config tweaks

## Testing
- `yarn lint:fix`
- `yarn test`

Closes #123

------
https://chatgpt.com/codex/tasks/task_e_68934eac11748326bc9dd11b86b51c45

## Summary by Sourcery

Add gentle audio cues for status and clue changes in the status sidebar and cover the functionality with tests

New Features:
- Add playStatusSound utility using Web Audio API to emit a beep
- Trigger playStatusSound in StatusSidebar when player status or clue count changes

Enhancements:
- Update ESLint config to set Next.js root directory

Tests:
- Add StatusSidebar test to verify audio cue is played on status or clue updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * StatusSidebar now plays a gentle beep sound whenever the player's status or the number of discovered clues changes, providing immediate audio feedback.
* **Tests**
  * Added and improved tests to verify that the status sound plays correctly on relevant state changes.
* **Chores**
  * Updated ESLint configuration to improve Next.js plugin compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->