### PR TITLE
feat(web): tweak scrollbar and focus ring

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -30,3 +30,31 @@ body {
   color: var(--foreground);
   font-family: var(--font-sans);
 }
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--brand) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 8px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: var(--brand);
+  border-radius: 0.5rem;
+  border: 2px solid transparent;
+}
+
+:focus {
+  outline: none;
+}
+
+:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary
- style scrollbars with brand colour and thin width
- refine focus ring using brand colour

## Testing
- `yarn lint:fix`
- `yarn web:ci`

Closes #123

------
https://chatgpt.com/codex/tasks/task_e_6894786e77508326bd50ff170848c31f

## Summary by Sourcery

Customize global scrollbar and focus styles to match the brand theme

Enhancements:
- Style scrollbars with thin width and brand color across browsers
- Refine focus ring to use brand color with no default outline and a visible outline-offset when focused

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated global styles to customise scrollbar appearance and focus outlines for a more cohesive and accessible user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->